### PR TITLE
feat: バトルドメインのエンティティとリポジトリIFを更新

### DIFF
--- a/server/src/modules/battle/domain/battle.repository.interface.ts
+++ b/server/src/modules/battle/domain/battle.repository.interface.ts
@@ -45,14 +45,17 @@ export interface IBattleRepository {
   /**
    * バトル中のポケモン状態を更新
    */
-  updateBattlePokemonStatus(id: number, data: Partial<BattlePokemonStatus>): Promise<BattlePokemonStatus>;
+  updateBattlePokemonStatus(
+    id: number,
+    data: Partial<BattlePokemonStatus>,
+  ): Promise<BattlePokemonStatus>;
 
   /**
    * アクティブなポケモンを取得（バトル中で場に出ているポケモン）
    */
   findActivePokemonByBattleIdAndTrainerId(
     battleId: number,
-    trainerId: number
+    trainerId: number,
   ): Promise<BattlePokemonStatus | null>;
 }
 
@@ -60,4 +63,3 @@ export interface IBattleRepository {
  * DIトークン（Nest.jsでインターフェースを注入するために使用）
  */
 export const BATTLE_REPOSITORY_TOKEN = Symbol('IBattleRepository');
-

--- a/server/src/modules/battle/domain/entities/battle-pokemon-status.entity.ts
+++ b/server/src/modules/battle/domain/entities/battle-pokemon-status.entity.ts
@@ -20,7 +20,7 @@ export class BattlePokemonStatus {
     public readonly speedRank: number,
     public readonly accuracyRank: number,
     public readonly evasionRank: number,
-    public readonly statusCondition: StatusCondition | null
+    public readonly statusCondition: StatusCondition | null,
   ) {}
 
   /**
@@ -33,7 +33,16 @@ export class BattlePokemonStatus {
   /**
    * 指定されたステータスランクを取得
    */
-  getStatRank(stat: 'attack' | 'defense' | 'specialAttack' | 'specialDefense' | 'speed' | 'accuracy' | 'evasion'): number {
+  getStatRank(
+    stat:
+      | 'attack'
+      | 'defense'
+      | 'specialAttack'
+      | 'specialDefense'
+      | 'speed'
+      | 'accuracy'
+      | 'evasion',
+  ): number {
     switch (stat) {
       case 'attack':
         return this.attackRank;
@@ -57,7 +66,16 @@ export class BattlePokemonStatus {
    * ランク: -6, -5, -4, -3, -2, -1, 0, +1, +2, +3, +4, +5, +6
    * 倍率: 2/8, 2/7, 2/6, 2/5, 2/4, 2/3, 1, 3/2, 4/2, 5/2, 6/2, 7/2, 8/2
    */
-  getStatMultiplier(stat: 'attack' | 'defense' | 'specialAttack' | 'specialDefense' | 'speed' | 'accuracy' | 'evasion'): number {
+  getStatMultiplier(
+    stat:
+      | 'attack'
+      | 'defense'
+      | 'specialAttack'
+      | 'specialDefense'
+      | 'speed'
+      | 'accuracy'
+      | 'evasion',
+  ): number {
     const rank = this.getStatRank(stat);
 
     if (rank === 0) {
@@ -73,4 +91,3 @@ export class BattlePokemonStatus {
     }
   }
 }
-

--- a/server/src/modules/battle/domain/entities/battle.entity.ts
+++ b/server/src/modules/battle/domain/entities/battle.entity.ts
@@ -13,7 +13,7 @@ export class Battle {
     public readonly weather: Weather | null,
     public readonly field: Field | null,
     public readonly status: BattleStatus,
-    public readonly winnerTrainerId: number | null
+    public readonly winnerTrainerId: number | null,
   ) {}
 }
 
@@ -38,4 +38,3 @@ export enum BattleStatus {
   Completed = 'Completed',
   Abandoned = 'Abandoned',
 }
-

--- a/server/src/modules/battle/domain/entities/status-condition.enum.ts
+++ b/server/src/modules/battle/domain/entities/status-condition.enum.ts
@@ -10,4 +10,3 @@ export enum StatusCondition {
   BadPoison = 'BadPoison', // もうどく
   Sleep = 'Sleep', // ねむり
 }
-


### PR DESCRIPTION
This pull request mainly refactors code formatting and improves code readability in several domain entity and interface files related to the battle module. The changes focus on consistent trailing commas in multi-line parameter lists and function signatures, as well as improved formatting for multi-line method parameters.

**Code formatting and readability improvements:**

* Added trailing commas to constructor parameter lists in `BattlePokemonStatus` and `Battle` classes for better readability and consistency. [[1]](diffhunk://#diff-99857534cc29554fe83ca82ef91c864047056d68bcef42ce678a05b871bbd851L23-R23) [[2]](diffhunk://#diff-13e371f361f55d7175f92f5a20a3d5019a26b421f1132329073d46204a91a87fL16-R16)
* Reformatted method signatures (`getStatRank`, `getStatMultiplier`, and `updateBattlePokemonStatus`) to use multi-line parameter lists with trailing commas, making the code easier to read and maintain. [[1]](diffhunk://#diff-99857534cc29554fe83ca82ef91c864047056d68bcef42ce678a05b871bbd851L36-R45) [[2]](diffhunk://#diff-99857534cc29554fe83ca82ef91c864047056d68bcef42ce678a05b871bbd851L60-R78) [[3]](diffhunk://#diff-dc36a1e6bce4e7bb33b19eb19fb3f36981e4164c45c213e1b8f9f034b89a70c6L48-L63)

**Minor cleanups:**

* Removed unnecessary trailing newlines at the end of several files and enums for codebase consistency. [[1]](diffhunk://#diff-99857534cc29554fe83ca82ef91c864047056d68bcef42ce678a05b871bbd851L76) [[2]](diffhunk://#diff-13e371f361f55d7175f92f5a20a3d5019a26b421f1132329073d46204a91a87fL41) [[3]](diffhunk://#diff-e5a0cc6119c7f15854715de18e753ce02c54415ca7d63bb3e5a0b39784623e23L13)- Battle, BattlePokemonStatus, StatusCondition の定義を更新
- battle.repository.interface の契約を拡張