### PR TITLE
feat: その他の主要な特性の実装（いとあみ、どくどく、せいでんき、もうふう）

### DIFF
--- a/server/prisma/seed-utils/ability-mapping.ts
+++ b/server/prisma/seed-utils/ability-mapping.ts
@@ -225,6 +225,22 @@ const abilityMetadataMap: Record<string, AbilityMetadata> = {
     triggerEvent: 'Passive',
     effectCategory: 'Other', // 相手の特性を無視（バトルで重要）
   },
+  いとあみ: {
+    triggerEvent: 'OnSwitchOut',
+    effectCategory: 'StatChange', // 場から下がるとき、相手の素早さを1段階下げる
+  },
+  どくどく: {
+    triggerEvent: 'OnTakingDamage',
+    effectCategory: 'StatusCondition', // 接触技を受けたとき、30%の確率で相手をどくにする
+  },
+  せいでんき: {
+    triggerEvent: 'OnTakingDamage',
+    effectCategory: 'StatusCondition', // 接触技を受けたとき、30%の確率で相手をまひにする
+  },
+  もうふう: {
+    triggerEvent: 'OnTakingDamage',
+    effectCategory: 'StatusCondition', // 接触技を受けたとき、30%の確率で相手をやけどにする
+  },
 };
 
 const defaultMetadata: AbilityMetadata = {

--- a/server/src/modules/battle/application/services/pokemon-switcher.service.ts
+++ b/server/src/modules/battle/application/services/pokemon-switcher.service.ts
@@ -44,6 +44,20 @@ export class PokemonSwitcherService {
     );
 
     if (currentActive) {
+      // 特性のOnSwitchOut効果を発動（状態異常解除前に実行）
+      const currentTrainedPokemon = await this.trainedPokemonRepository.findById(
+        currentActive.trainedPokemonId,
+      );
+      if (currentTrainedPokemon?.ability) {
+        const abilityEffect = AbilityRegistry.get(currentTrainedPokemon.ability.name);
+        if (abilityEffect?.onSwitchOut) {
+          await abilityEffect.onSwitchOut(currentActive, {
+            battle,
+            battleRepository: this.battleRepository,
+          });
+        }
+      }
+
       // 状態異常を解除（交代時に解除されるもの）
       const statusCondition = StatusConditionHandler.isClearedOnSwitch(
         currentActive.statusCondition,

--- a/server/src/modules/battle/domain/logic/damage-calculator.ts
+++ b/server/src/modules/battle/domain/logic/damage-calculator.ts
@@ -249,6 +249,7 @@ export class DamageCalculator {
               weather: params.weather,
               field: params.field,
               moveTypeName: params.moveType.name,
+              moveCategory: params.move.category,
             }
           : undefined;
         const modifiedDamage = abilityEffect.modifyDamage(defender, currentDamage, battleContext);

--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -22,6 +22,10 @@ import { DrizzleEffect } from './effects/weather/drizzle-effect';
 import { DroughtEffect } from './effects/weather/drought-effect';
 import { SandStreamEffect } from './effects/weather/sand-stream-effect';
 import { SnowWarningEffect } from './effects/weather/snow-warning-effect';
+import { StickyWebEffect } from './effects/stat-change/sticky-web-effect';
+import { PoisonPointEffect } from './effects/stat-change/poison-point-effect';
+import { StaticEffect } from './effects/stat-change/static-effect';
+import { FlameBodyEffect } from './effects/stat-change/flame-body-effect';
 
 /**
  * 特性レジストリ
@@ -70,6 +74,10 @@ export class AbilityRegistry {
       this.registry.set('しんりょく', new ShinryokuEffect());
       this.registry.set('もうか', new MoukaEffect());
       this.registry.set('げきりゅう', new GekiryuuEffect());
+      this.registry.set('いとあみ', new StickyWebEffect());
+      this.registry.set('どくどく', new PoisonPointEffect());
+      this.registry.set('せいでんき', new StaticEffect());
+      this.registry.set('もうふう', new FlameBodyEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize AbilityRegistry: ${error instanceof Error ? error.message : String(error)}`,

--- a/server/src/modules/pokemon/domain/abilities/battle-context.interface.ts
+++ b/server/src/modules/pokemon/domain/abilities/battle-context.interface.ts
@@ -53,4 +53,10 @@ export interface BattleContext {
    * BaseMultiHitEffectで設定される
    */
   multiHitCount?: number;
+
+  /**
+   * 技のカテゴリ（Physical, Special, Status）
+   * 接触技の判定などで使用
+   */
+  moveCategory?: 'Physical' | 'Special' | 'Status';
 }

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-contact-status-condition-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-contact-status-condition-effect.spec.ts
@@ -1,0 +1,307 @@
+import { BaseContactStatusConditionEffect } from './base-contact-status-condition-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+import { IBattleRepository } from '@/modules/battle/domain/battle.repository.interface';
+import { ITrainedPokemonRepository } from '@/modules/trainer/domain/trainer.repository.interface';
+import { TrainedPokemon } from '@/modules/trainer/domain/entities/trained-pokemon.entity';
+import { Pokemon } from '@/modules/pokemon/domain/entities/pokemon.entity';
+import { Type } from '@/modules/pokemon/domain/entities/type.entity';
+import { Ability } from '@/modules/pokemon/domain/entities/ability.entity';
+import { Gender } from '@/modules/trainer/domain/entities/trained-pokemon.entity';
+import { Nature } from '@/modules/battle/domain/logic/stat-calculator';
+import { AbilityRegistry } from '../../ability-registry';
+
+/**
+ * テスト用の具象クラス（どくを付与）
+ */
+class TestPoisonContactEffect extends BaseContactStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 1.0; // テスト用に100%に設定
+  protected readonly immuneTypes = ['どく', 'はがね'] as const;
+}
+
+describe('BaseContactStatusConditionEffect', () => {
+  // テスト用のヘルパー関数
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus => {
+    return new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+  };
+
+  const createType = (id: number, name: string = `Type${id}`, nameEn: string = `Type${id}En`): Type => {
+    return new Type(id, name, nameEn);
+  };
+
+  const createPokemon = (
+    id: number,
+    primaryType: Type,
+    secondaryType: Type | null = null,
+  ): Pokemon => {
+    return new Pokemon(
+      id,
+      1,
+      'TestPokemon',
+      'TestPokemon',
+      primaryType,
+      secondaryType,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+    );
+  };
+
+  const createTrainedPokemon = (
+    id: number,
+    pokemon: Pokemon,
+    ability: Ability | null = null,
+  ): TrainedPokemon => {
+    return new TrainedPokemon(
+      id,
+      1,
+      pokemon,
+      null,
+      50,
+      Gender.Male,
+      Nature.Hardy,
+      ability,
+      31,
+      31,
+      31,
+      31,
+      31,
+      31,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    );
+  };
+
+  const createMockBattleRepository = (): jest.Mocked<IBattleRepository> => {
+    return {
+      findById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findBattlePokemonStatusByBattleId: jest.fn(),
+      createBattlePokemonStatus: jest.fn(),
+      updateBattlePokemonStatus: jest.fn(),
+      findActivePokemonByBattleIdAndTrainerId: jest.fn(),
+      findBattlePokemonStatusById: jest.fn(),
+      findBattlePokemonMovesByBattlePokemonStatusId: jest.fn(),
+      createBattlePokemonMove: jest.fn(),
+      updateBattlePokemonMove: jest.fn(),
+      findBattlePokemonMoveById: jest.fn(),
+    };
+  };
+
+  const createMockTrainedPokemonRepository = (
+    trainedPokemon: TrainedPokemon | null,
+  ): jest.Mocked<ITrainedPokemonRepository> => {
+    return {
+      findById: jest.fn().mockResolvedValue(trainedPokemon),
+      findByTrainerId: jest.fn(),
+    };
+  };
+
+  describe('applyContactStatusCondition', () => {
+    it('battleContextがない場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, undefined);
+
+      expect(result).toBe(false);
+    });
+
+    it('battleRepositoryがない場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        // battleRepository を提供しない
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+    });
+
+    it('接触技でない場合（Special）、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleRepository = createMockBattleRepository();
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        moveCategory: 'Special',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('接触技でない場合（Status）、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleRepository = createMockBattleRepository();
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        moveCategory: 'Status',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('攻撃側が既に状態異常を持っている場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2, statusCondition: StatusCondition.Burn });
+      const battleRepository = createMockBattleRepository();
+      const trainedPokemonRepository = createMockTrainedPokemonRepository(
+        createTrainedPokemon(2, createPokemon(2, createType(1, 'ほのお'))),
+      );
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        trainedPokemonRepository,
+        moveCategory: 'Physical',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('攻撃側のポケモンが見つからない場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleRepository = createMockBattleRepository();
+      const trainedPokemonRepository = createMockTrainedPokemonRepository(null);
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        trainedPokemonRepository,
+        moveCategory: 'Physical',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('免疫タイプ（プライマリ）の場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleRepository = createMockBattleRepository();
+      const trainedPokemonRepository = createMockTrainedPokemonRepository(
+        createTrainedPokemon(2, createPokemon(2, createType(1, 'どく'))),
+      );
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        trainedPokemonRepository,
+        moveCategory: 'Physical',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('免疫タイプ（セカンダリ）の場合、falseを返す', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2 });
+      const battleRepository = createMockBattleRepository();
+      const trainedPokemonRepository = createMockTrainedPokemonRepository(
+        createTrainedPokemon(
+          2,
+          createPokemon(2, createType(1, 'ほのお'), createType(2, 'はがね')),
+        ),
+      );
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        trainedPokemonRepository,
+        moveCategory: 'Physical',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(false);
+      expect(battleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('正常に状態異常を付与する', async () => {
+      const effect = new TestPoisonContactEffect();
+      const defender = createBattlePokemonStatus();
+      const attacker = createBattlePokemonStatus({ id: 2, statusCondition: null });
+      const battleRepository = createMockBattleRepository();
+      const trainedPokemonRepository = createMockTrainedPokemonRepository(
+        createTrainedPokemon(2, createPokemon(2, createType(1, 'ほのお'))),
+      );
+      const battleContext: BattleContext = {
+        battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+        battleRepository,
+        trainedPokemonRepository,
+        moveCategory: 'Physical',
+      };
+
+      const result = await effect.applyContactStatusCondition(defender, attacker, battleContext);
+
+      expect(result).toBe(true);
+      expect(battleRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(2, {
+        statusCondition: StatusCondition.Poison,
+      });
+    });
+
+    it('modifyDamageはダメージを変更しない', () => {
+      const effect = new TestPoisonContactEffect();
+      const pokemon = createBattlePokemonStatus();
+      const damage = 100;
+
+      const result = effect.modifyDamage(pokemon, damage, undefined);
+
+      expect(result).toBe(damage);
+    });
+  });
+});
+

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-contact-status-condition-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-contact-status-condition-effect.ts
@@ -1,0 +1,110 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 接触技を受けたときに状態異常を付与する基底クラス
+ * どくどく（Poison Point）、せいでんき（Static）、もうふう（Flame Body）などで使用
+ *
+ * 各特性は、このクラスを継承してパラメータを設定するだけで実装できる
+ */
+export abstract class BaseContactStatusConditionEffect implements IAbilityEffect {
+  /**
+   * ダメージ修正（この特性はダメージを修正しない）
+   */
+  modifyDamage(_pokemon: BattlePokemonStatus, damage: number, _battleContext?: BattleContext): number {
+    return damage;
+  }
+  /**
+   * 付与する状態異常
+   */
+  protected abstract readonly statusCondition: StatusCondition;
+
+  /**
+   * 状態異常を付与する確率（0.0-1.0、例: 0.3は30%）
+   */
+  protected abstract readonly chance: number;
+
+  /**
+   * 状態異常を付与できないタイプ（免疫タイプ）
+   */
+  protected abstract readonly immuneTypes: readonly string[];
+
+  /**
+   * 接触技を受けたときに状態異常を付与する
+   * MoveExecutorServiceから呼び出される
+   *
+   * @param defender 防御側のポケモン（状態異常を付与される側）
+   * @param attacker 攻撃側のポケモン（状態異常を付与する側）
+   * @param battleContext バトルコンテキスト
+   * @returns 状態異常を付与した場合はtrue、付与しなかった場合はfalse
+   */
+  async applyContactStatusCondition(
+    defender: BattlePokemonStatus,
+    attacker: BattlePokemonStatus,
+    battleContext?: BattleContext,
+  ): Promise<boolean> {
+    if (!battleContext?.battleRepository || !battleContext.trainedPokemonRepository) {
+      return false;
+    }
+
+    // 接触技でない場合は処理しない
+    if (battleContext.moveCategory !== 'Physical') {
+      return false;
+    }
+
+    // 既に状態異常がある場合は付与しない
+    if (attacker.statusCondition && attacker.statusCondition !== StatusCondition.None) {
+      return false;
+    }
+
+    // 攻撃側のポケモンのタイプを取得
+    const attackerTrainedPokemon = await battleContext.trainedPokemonRepository.findById(
+      attacker.trainedPokemonId,
+    );
+    if (!attackerTrainedPokemon) {
+      return false;
+    }
+
+    // タイプによる免疫チェック
+    const hasImmuneType =
+      this.immuneTypes.includes(attackerTrainedPokemon.pokemon.primaryType.name) ||
+      (attackerTrainedPokemon.pokemon.secondaryType &&
+        this.immuneTypes.includes(attackerTrainedPokemon.pokemon.secondaryType.name));
+    if (hasImmuneType) {
+      return false;
+    }
+
+    // 特性による無効化チェック（動的に取得して循環参照を回避）
+    if (attackerTrainedPokemon.ability) {
+      // 動的インポートで循環参照を回避
+      const { AbilityRegistry } = await import('../../ability-registry');
+      const abilityEffect = AbilityRegistry.get(attackerTrainedPokemon.ability.name);
+      if (abilityEffect?.canReceiveStatusCondition) {
+        const canReceive = abilityEffect.canReceiveStatusCondition(
+          attacker,
+          this.statusCondition,
+          battleContext,
+        );
+        // canReceiveがfalseの場合は無効化（undefinedの場合は判定しない）
+        if (canReceive === false) {
+          return false;
+        }
+      }
+    }
+
+    // 確率判定（chanceが1.0の場合は必ず付与）
+    if (this.chance < 1.0 && Math.random() >= this.chance) {
+      return false;
+    }
+
+    // 状態異常を付与
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      statusCondition: this.statusCondition,
+    });
+
+    return true;
+  }
+}
+

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-opponent-stat-change-on-switch-out-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-opponent-stat-change-on-switch-out-effect.ts
@@ -1,0 +1,71 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatType } from './base-opponent-stat-change-effect';
+
+/**
+ * 場から下がるとき（onSwitchOut）に相手のステータスランクを変更する基底クラス
+ * いとあみ（Sticky Web）などで使用
+ *
+ * 各特性は、このクラスを継承してパラメータを設定するだけで実装できる
+ */
+export abstract class BaseOpponentStatChangeOnSwitchOutEffect implements IAbilityEffect {
+  /**
+   * 変更するステータスの種類
+   */
+  protected abstract readonly statType: StatType;
+
+  /**
+   * 変更するランク数（正の値で上昇、負の値で下降）
+   */
+  protected abstract readonly rankChange: number;
+
+  /**
+   * 場から下がるときに発動
+   * 相手のステータスランクを変更
+   */
+  async onSwitchOut(pokemon: BattlePokemonStatus, battleContext?: BattleContext): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    const battle = battleContext.battle;
+
+    // 相手のトレーナーIDを取得
+    const opponentTrainerId =
+      pokemon.trainerId === battle.trainer1Id ? battle.trainer2Id : battle.trainer1Id;
+
+    // 相手のアクティブなポケモンを取得
+    const opponentPokemon = await battleContext.battleRepository.findActivePokemonByBattleIdAndTrainerId(
+      battle.id,
+      opponentTrainerId,
+    );
+
+    if (!opponentPokemon) {
+      return;
+    }
+
+    // 現在のランクを取得
+    const currentRank = opponentPokemon.getStatRank(this.statType);
+
+    // 新しいランクを計算（-6から+6の範囲内で）
+    const newRank = Math.max(-6, Math.min(6, currentRank + this.rankChange));
+
+    // statTypeからプロパティ名をマッピングしてupdateDataを構築
+    const statRankPropMap: Record<StatType, keyof BattlePokemonStatus> = {
+      attack: 'attackRank',
+      defense: 'defenseRank',
+      specialAttack: 'specialAttackRank',
+      specialDefense: 'specialDefenseRank',
+      speed: 'speedRank',
+      accuracy: 'accuracyRank',
+      evasion: 'evasionRank',
+    };
+    const propName = statRankPropMap[this.statType];
+    const updateData: Partial<BattlePokemonStatus> = { [propName]: newRank } as Partial<BattlePokemonStatus>;
+
+    // 相手のステータスランクを更新
+    await battleContext.battleRepository.updateBattlePokemonStatus(opponentPokemon.id, updateData);
+  }
+}
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/flame-body-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/flame-body-effect.spec.ts
@@ -1,0 +1,22 @@
+import { FlameBodyEffect } from './flame-body-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+describe('FlameBodyEffect', () => {
+  describe('基本設定', () => {
+    it('状態異常がやけどである', () => {
+      const effect = new FlameBodyEffect();
+      expect((effect as any).statusCondition).toBe(StatusCondition.Burn);
+    });
+
+    it('確率が30%である', () => {
+      const effect = new FlameBodyEffect();
+      expect((effect as any).chance).toBe(0.3);
+    });
+
+    it('免疫タイプがほのおである', () => {
+      const effect = new FlameBodyEffect();
+      expect((effect as any).immuneTypes).toEqual(['ほのお']);
+    });
+  });
+});
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/flame-body-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/flame-body-effect.ts
@@ -1,0 +1,13 @@
+import { BaseContactStatusConditionEffect } from '../base/base-contact-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * もうふう（Flame Body）特性の効果
+ * 接触技を受けたとき、30%の確率で相手をやけどにする
+ */
+export class FlameBodyEffect extends BaseContactStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['ほのお'] as const;
+}
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/poison-point-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/poison-point-effect.spec.ts
@@ -1,0 +1,22 @@
+import { PoisonPointEffect } from './poison-point-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+describe('PoisonPointEffect', () => {
+  describe('基本設定', () => {
+    it('状態異常がどくである', () => {
+      const effect = new PoisonPointEffect();
+      expect((effect as any).statusCondition).toBe(StatusCondition.Poison);
+    });
+
+    it('確率が30%である', () => {
+      const effect = new PoisonPointEffect();
+      expect((effect as any).chance).toBe(0.3);
+    });
+
+    it('免疫タイプがどく、はがねである', () => {
+      const effect = new PoisonPointEffect();
+      expect((effect as any).immuneTypes).toEqual(['どく', 'はがね']);
+    });
+  });
+});
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/poison-point-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/poison-point-effect.ts
@@ -1,0 +1,13 @@
+import { BaseContactStatusConditionEffect } from '../base/base-contact-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * どくどく（Poison Point）特性の効果
+ * 接触技を受けたとき、30%の確率で相手をどくにする
+ */
+export class PoisonPointEffect extends BaseContactStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'] as const;
+}
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/static-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/static-effect.spec.ts
@@ -1,0 +1,22 @@
+import { StaticEffect } from './static-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+describe('StaticEffect', () => {
+  describe('基本設定', () => {
+    it('状態異常がまひである', () => {
+      const effect = new StaticEffect();
+      expect((effect as any).statusCondition).toBe(StatusCondition.Paralysis);
+    });
+
+    it('確率が30%である', () => {
+      const effect = new StaticEffect();
+      expect((effect as any).chance).toBe(0.3);
+    });
+
+    it('免疫タイプがでんきである', () => {
+      const effect = new StaticEffect();
+      expect((effect as any).immuneTypes).toEqual(['でんき']);
+    });
+  });
+});
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/static-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/static-effect.ts
@@ -1,0 +1,13 @@
+import { BaseContactStatusConditionEffect } from '../base/base-contact-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * せいでんき（Static）特性の効果
+ * 接触技を受けたとき、30%の確率で相手をまひにする
+ */
+export class StaticEffect extends BaseContactStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'] as const;
+}
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/sticky-web-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/sticky-web-effect.spec.ts
@@ -1,0 +1,238 @@
+import { StickyWebEffect } from './sticky-web-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+import { IBattleRepository } from '@/modules/battle/domain/battle.repository.interface';
+
+describe('StickyWebEffect', () => {
+  // テスト用のヘルパー関数
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus => {
+    return new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+  };
+
+  const createBattle = (overrides?: Partial<Battle>): Battle => {
+    return new Battle(
+      overrides?.id ?? 1,
+      overrides?.trainer1Id ?? 1,
+      overrides?.trainer2Id ?? 2,
+      overrides?.team1Id ?? 1,
+      overrides?.team2Id ?? 2,
+      overrides?.turn ?? 1,
+      overrides?.weather ?? null,
+      overrides?.field ?? null,
+      overrides?.status ?? BattleStatus.Active,
+      overrides?.winnerTrainerId ?? null,
+    );
+  };
+
+  const createMockBattleRepository = (): jest.Mocked<IBattleRepository> => {
+    return {
+      findById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findBattlePokemonStatusByBattleId: jest.fn(),
+      createBattlePokemonStatus: jest.fn(),
+      updateBattlePokemonStatus: jest.fn(),
+      findActivePokemonByBattleIdAndTrainerId: jest.fn(),
+      findBattlePokemonStatusById: jest.fn(),
+      findBattlePokemonMovesByBattlePokemonStatusId: jest.fn(),
+      createBattlePokemonMove: jest.fn(),
+      updateBattlePokemonMove: jest.fn(),
+      findBattlePokemonMoveById: jest.fn(),
+    };
+  };
+
+  describe('onSwitchOut', () => {
+    it('battleContextがない場合、何も実行しない', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+
+      await expect(effect.onSwitchOut(pokemon, undefined)).resolves.not.toThrow();
+    });
+
+    it('battleRepositoryがない場合、何も実行しない', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const battle = createBattle();
+      const battleContext: BattleContext = {
+        battle,
+        // battleRepository を提供しない
+      };
+
+      await expect(effect.onSwitchOut(pokemon, battleContext)).resolves.not.toThrow();
+    });
+
+    it('相手のポケモンが見つからない場合、何も実行しない', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(null);
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.findActivePokemonByBattleIdAndTrainerId).toHaveBeenCalledWith(
+        battle.id,
+        2, // 相手のトレーナーID
+      );
+      expect(mockRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('正常に相手の素早さランクを1段階下げる', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const opponentPokemon = createBattlePokemonStatus({
+        id: 2,
+        trainerId: 2,
+        speedRank: 0,
+      });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(opponentPokemon);
+      mockRepository.updateBattlePokemonStatus.mockResolvedValue(
+        createBattlePokemonStatus({ id: 2, speedRank: -1 }),
+      );
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.findActivePokemonByBattleIdAndTrainerId).toHaveBeenCalledWith(
+        battle.id,
+        2,
+      );
+      expect(mockRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(2, {
+        speedRank: -1,
+      });
+    });
+
+    it('相手の素早さランクが+6の場合、+5になる（上限チェック）', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const opponentPokemon = createBattlePokemonStatus({
+        id: 2,
+        trainerId: 2,
+        speedRank: 6,
+      });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(opponentPokemon);
+      mockRepository.updateBattlePokemonStatus.mockResolvedValue(opponentPokemon);
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(2, {
+        speedRank: 5,
+      });
+    });
+
+    it('相手の素早さランクが-6の場合、-6のまま（下限チェック）', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const opponentPokemon = createBattlePokemonStatus({
+        id: 2,
+        trainerId: 2,
+        speedRank: -6,
+      });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(opponentPokemon);
+      mockRepository.updateBattlePokemonStatus.mockResolvedValue(opponentPokemon);
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(2, {
+        speedRank: -6,
+      }); // -6 + (-1) = -7 → Math.max(-6, -7) = -6
+    });
+
+    it('trainer1Idのポケモンが場から下がった場合、trainer2Idのポケモンのランクを変更', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 1 });
+      const opponentPokemon = createBattlePokemonStatus({
+        id: 2,
+        trainerId: 2,
+        speedRank: 0,
+      });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(opponentPokemon);
+      mockRepository.updateBattlePokemonStatus.mockResolvedValue(opponentPokemon);
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.findActivePokemonByBattleIdAndTrainerId).toHaveBeenCalledWith(
+        battle.id,
+        2,
+      );
+    });
+
+    it('trainer2Idのポケモンが場から下がった場合、trainer1Idのポケモンのランクを変更', async () => {
+      const effect = new StickyWebEffect();
+      const pokemon = createBattlePokemonStatus({ trainerId: 2 });
+      const opponentPokemon = createBattlePokemonStatus({
+        id: 1,
+        trainerId: 1,
+        speedRank: 0,
+      });
+      const battle = createBattle({ trainer1Id: 1, trainer2Id: 2 });
+      const mockRepository = createMockBattleRepository();
+      mockRepository.findActivePokemonByBattleIdAndTrainerId.mockResolvedValue(opponentPokemon);
+      mockRepository.updateBattlePokemonStatus.mockResolvedValue(opponentPokemon);
+
+      const battleContext: BattleContext = {
+        battle,
+        battleRepository: mockRepository,
+      };
+
+      await effect.onSwitchOut(pokemon, battleContext);
+
+      expect(mockRepository.findActivePokemonByBattleIdAndTrainerId).toHaveBeenCalledWith(
+        battle.id,
+        1,
+      );
+    });
+  });
+});
+

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/sticky-web-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/sticky-web-effect.ts
@@ -1,0 +1,11 @@
+import { BaseOpponentStatChangeOnSwitchOutEffect } from '../base/base-opponent-stat-change-on-switch-out-effect';
+
+/**
+ * いとあみ（Sticky Web）特性の効果
+ * 場から下がるとき、相手の素早さを1段階下げる
+ */
+export class StickyWebEffect extends BaseOpponentStatChangeOnSwitchOutEffect {
+  protected readonly statType = 'speed' as const;
+  protected readonly rankChange = -1;
+}
+


### PR DESCRIPTION
## 概要
Issue #46の対応として、その他の主要な特性を実装しました。

## 実装内容

### 実装した特性
1. **いとあみ（Sticky Web）**: 場から下がるとき、相手の素早さを1段階下げる
2. **どくどく（Poison Point）**: 接触技を受けたとき、30%の確率で相手をどくにする
3. **せいでんき（Static）**: 接触技を受けたとき、30%の確率で相手をまひにする
4. **もうふう（Flame Body）**: 接触技を受けたとき、30%の確率で相手をやけどにする

### 技術的な変更
- BattleContextにmoveCategoryを追加し、接触技の判定を可能にした
- BaseOpponentStatChangeOnSwitchOutEffect基底クラスを追加（onSwitchOutで相手のステータスを変更）
- BaseContactStatusConditionEffect基底クラスを追加（接触技による状態異常付与）
- PokemonSwitcherServiceでonSwitchOutを呼び出す実装を追加
- MoveExecutorServiceで接触技による状態異常付与の処理を追加
- ability-mapping.tsにマッピングを追加
- AbilityRegistryに登録

## テスト結果
- テスト: 27テストケース、全て成功
- build: 成功

## 関連Issue
- Issue #46: その他の主要な特性の実装