### PR TITLE
fix: 未使用の型定義とインポートを削除してlintエラーを解消

### DIFF
--- a/server/src/modules/pokemon/infrastructure/persistence/pokemon.prisma.repository.ts
+++ b/server/src/modules/pokemon/infrastructure/persistence/pokemon.prisma.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/shared/prisma/prisma.service';
-import { Prisma } from '@generated/prisma/client';
 import {
   IPokemonRepository,
   IAbilityRepository,
@@ -12,30 +11,6 @@ import { Pokemon } from '../../domain/entities/pokemon.entity';
 import { Ability } from '../../domain/entities/ability.entity';
 import { Move } from '../../domain/entities/move.entity';
 import { PokemonMapper, AbilityMapper, MoveMapper } from '@/shared/infrastructure/mappers';
-
-/**
- * PokemonのPrismaクエリ結果型（include付き）
- */
-type PokemonWithTypes = Prisma.PokemonGetPayload<{
-  include: {
-    primaryType: true;
-    secondaryType: true;
-  };
-}>;
-
-/**
- * MoveのPrismaクエリ結果型（include付き）
- */
-type MoveWithRelations = Prisma.MoveGetPayload<{
-  include: {
-    type: true;
-  };
-}>;
-
-/**
- * AbilityのPrismaクエリ結果型
- */
-type AbilityData = Prisma.AbilityGetPayload<{}>;
 
 /**
  * PokemonリポジトリのPrisma実装

--- a/server/src/shared/infrastructure/mappers/trained-pokemon.mapper.ts
+++ b/server/src/shared/infrastructure/mappers/trained-pokemon.mapper.ts
@@ -1,7 +1,5 @@
 import { Prisma } from '@generated/prisma/client';
 import { TrainedPokemon, Gender } from '@/modules/trainer/domain/entities/trained-pokemon.entity';
-import { Pokemon } from '@/modules/pokemon/domain/entities/pokemon.entity';
-import { Ability } from '@/modules/pokemon/domain/entities/ability.entity';
 import { Nature } from '@/modules/battle/domain/logic/stat-calculator';
 import { PokemonMapper } from './pokemon.mapper';
 import { AbilityMapper } from './ability.mapper';


### PR DESCRIPTION
## 概要
lintエラーを解消するため、未使用の型定義とインポートを削除しました。

## 変更内容
- `pokemon.prisma.repository.ts`: 未使用の型定義（`PokemonWithTypes`, `MoveWithRelations`, `AbilityData`）と`Prisma`インポートを削除
- `trained-pokemon.mapper.ts`: 未使用のインポート（`Pokemon`, `Ability`）を削除

## 確認事項
- [x] `npm run lint` がエラーなく通過すること
- [x] `npm run build` が成功すること