### PR TITLE
feat: 変化カテゴリやけど付与の技効果を追加 (Issue #116)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/refresh-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/refresh-effect.spec.ts
@@ -1,0 +1,86 @@
+import { RefreshEffect } from './refresh-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('RefreshEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it.each([
+    ['やけど', StatusCondition.Burn],
+    ['まひ', StatusCondition.Paralysis],
+    ['どく', StatusCondition.Poison],
+    ['もうどく', StatusCondition.BadPoison],
+  ])('自分の%s状態を回復する', async (_label, condition) => {
+    const effect = new RefreshEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: condition });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('The user was cured of its status condition!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it.each([
+    ['ねむり', StatusCondition.Sleep],
+    ['こおり', StatusCondition.Freeze],
+    ['こんらん', StatusCondition.Confusion],
+  ])('対象外の%s状態は回復しない', async (_label, condition) => {
+    const effect = new RefreshEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: condition });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('状態異常がない場合は何もしない', async () => {
+    const effect = new RefreshEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: null });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/refresh-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/refresh-effect.ts
@@ -1,0 +1,41 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「リフレッシュ」の特殊効果実装
+ *
+ * 効果: 自分のやけど・まひ・どく（もうどく含む）を回復する
+ */
+export class RefreshEffect implements IMoveEffect {
+  private static readonly CURABLE_CONDITIONS: ReadonlySet<StatusCondition> = new Set([
+    StatusCondition.Burn,
+    StatusCondition.Paralysis,
+    StatusCondition.Poison,
+    StatusCondition.BadPoison,
+  ]);
+
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    if (
+      !attacker.statusCondition ||
+      !RefreshEffect.CURABLE_CONDITIONS.has(attacker.statusCondition)
+    ) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      statusCondition: StatusCondition.None,
+    });
+
+    return 'The user was cured of its status condition!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/will-o-wisp-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/will-o-wisp-effect.spec.ts
@@ -1,0 +1,101 @@
+import { WillOWispEffect } from './will-o-wisp-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('WillOWispEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (overrides?: {
+    defenderPrimaryTypeName?: string;
+    defenderSecondaryTypeName?: string | null;
+  }): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockTrainedPokemonRepository = {
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        pokemon: {
+          id: 1,
+          primaryType: { name: overrides?.defenderPrimaryTypeName ?? 'ノーマル' },
+          secondaryType:
+            overrides?.defenderSecondaryTypeName !== undefined
+              ? overrides.defenderSecondaryTypeName
+                ? { name: overrides.defenderSecondaryTypeName }
+                : null
+              : null,
+        },
+        ability: null,
+      }),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+      trainedPokemonRepository:
+        mockTrainedPokemonRepository as unknown as BattleContext['trainedPokemonRepository'],
+    };
+  };
+
+  it('相手に必ずやけどを付与する', async () => {
+    const effect = new WillOWispEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe('was burned!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Burn,
+    });
+  });
+
+  it('ほのおタイプには付与しない', async () => {
+    const effect = new WillOWispEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext({ defenderPrimaryTypeName: 'ほのお' });
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('既に状態異常がある場合は付与しない', async () => {
+    const effect = new WillOWispEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({
+      id: 2,
+      statusCondition: StatusCondition.Paralysis,
+    });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/will-o-wisp-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/will-o-wisp-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「おにび」の特殊効果実装
+ *
+ * 効果: 必ず相手にやけどを付与 (Burns the target)
+ */
+export class WillOWispEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -51,6 +51,8 @@ import { SteamEruptionEffect } from './effects/steam-eruption-effect';
 import { BlueFlareEffect } from './effects/blue-flare-effect';
 import { SparklingAriaEffect } from './effects/sparkling-aria-effect';
 import { ScorchingSandsEffect } from './effects/scorching-sands-effect';
+import { WillOWispEffect } from './effects/will-o-wisp-effect';
+import { RefreshEffect } from './effects/refresh-effect';
 
 /**
  * 技のレジストリ
@@ -132,6 +134,9 @@ export class MoveRegistry {
       this.registry.set('あおいほのお', new BlueFlareEffect());
       this.registry.set('うたかたのアリア', new SparklingAriaEffect());
       this.registry.set('ねっさのだいち', new ScorchingSandsEffect());
+      // やけど付与系の変化技（Issue #116）
+      this.registry.set('おにび', new WillOWispEffect());
+      this.registry.set('リフレッシュ', new RefreshEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
- Issue #116 「変化カテゴリの未実装技の特殊効果の実装: やけど付与 (2件)」を実装
- `おにび` (Will-o-Wisp): 相手にやけど確定付与（ほのおタイプ免疫）— `BaseStatusConditionEffect` 継承で `chance=1.0`
- `リフレッシュ` (Refresh): 自分のやけど・まひ・どく（もうどく含む）を回復する自己回復技
- `MoveRegistry` に両者を登録

## 設計メモ
- `おにび` は既存の `ToxicEffect` / `LavaPlumeEffect` と同じ `BaseStatusConditionEffect` 継承パターン
- `リフレッシュ` は `SparklingAriaEffect`（相手のやけど回復）を参考にした自己版。回復対象は `Set<StatusCondition>` で明示
- 本家準拠で「どく」には `BadPoison` も含めた

## Test plan
- [x] `will-o-wisp-effect.spec.ts` 追加（3 ケース: 確定付与 / ほのお免疫 / 既存状態異常スキップ）
- [x] `refresh-effect.spec.ts` 追加（対象4状態 + 対象外3状態 + 状態異常なしの計8ケース）
- [x] `npm test`: 121 suites / 701 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #116