### PR TITLE
feat: 物理カテゴリやけど付与の技効果を追加 (Issue #123)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/blaze-kick-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/blaze-kick-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ブレイズキック」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にやけどを付与 (Has a 10% chance to burn the target)
+ * 注: 急所率上昇は別処理（ダメージ計算側）で扱う
+ */
+export class BlazeKickEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/fire-punch-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/fire-punch-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ほのおのパンチ」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にやけどを付与 (Has a 10% chance to burn the target)
+ */
+export class FirePunchEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/flame-wheel-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/flame-wheel-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「かえんぐるま」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にやけどを付与 (Has a 10% chance to burn the target)
+ * 注: 自分のこおり状態を解除する効果は別処理（バトルフロー）で扱う
+ */
+export class FlameWheelEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/flare-blitz-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/flare-blitz-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「フレアドライブ」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にやけどを付与 (Has a 10% chance to burn the target)
+ * 注: 反動ダメージ（与えたダメージの1/3）は別 Issue #127（反動ダメージ系）で扱う
+ */
+export class FlareBlitzEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/physical-burn-effects.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/physical-burn-effects.spec.ts
@@ -1,0 +1,119 @@
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+import { IMoveEffect } from '../move-effect.interface';
+import { FirePunchEffect } from './fire-punch-effect';
+import { FlameWheelEffect } from './flame-wheel-effect';
+import { SacredFireEffect } from './sacred-fire-effect';
+import { BlazeKickEffect } from './blaze-kick-effect';
+import { FlareBlitzEffect } from './flare-blitz-effect';
+import { PyroBallEffect } from './pyro-ball-effect';
+
+/**
+ * 物理カテゴリやけど付与系の技（Issue #123）の設定検証
+ * BaseStatusConditionEffect 拡張の確率・免疫タイプ・メッセージを検証する
+ */
+describe('物理カテゴリやけど付与の技効果（Issue #123）', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (defenderTypeName = 'ノーマル'): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockTrainedPokemonRepository = {
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        pokemon: { id: 1, primaryType: { name: defenderTypeName }, secondaryType: null },
+        ability: null,
+      }),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+      trainedPokemonRepository:
+        mockTrainedPokemonRepository as unknown as BattleContext['trainedPokemonRepository'],
+    };
+  };
+
+  type EffectCase = {
+    name: string;
+    effect: IMoveEffect;
+    expectedChance: number;
+    randomBelow: number; // この値で確率判定を通る
+    randomAbove: number; // この値で確率判定を外す
+  };
+
+  const cases: EffectCase[] = [
+    { name: 'ほのおのパンチ', effect: new FirePunchEffect(), expectedChance: 0.1, randomBelow: 0.05, randomAbove: 0.5 },
+    { name: 'かえんぐるま', effect: new FlameWheelEffect(), expectedChance: 0.1, randomBelow: 0.05, randomAbove: 0.5 },
+    { name: 'せいなるほのお', effect: new SacredFireEffect(), expectedChance: 0.5, randomBelow: 0.2, randomAbove: 0.8 },
+    { name: 'ブレイズキック', effect: new BlazeKickEffect(), expectedChance: 0.1, randomBelow: 0.05, randomAbove: 0.5 },
+    { name: 'フレアドライブ', effect: new FlareBlitzEffect(), expectedChance: 0.1, randomBelow: 0.05, randomAbove: 0.5 },
+    { name: 'かえんボール', effect: new PyroBallEffect(), expectedChance: 0.1, randomBelow: 0.05, randomAbove: 0.5 },
+  ];
+
+  it.each(cases)('$name は確率内でやけどを付与する', async ({ effect, randomBelow }) => {
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(randomBelow);
+    const result = await effect.onHit!(attacker, defender, ctx);
+
+    expect(result).toBe('was burned!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Burn,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it.each(cases)('$name は確率外ではやけどを付与しない', async ({ effect, expectedChance, randomAbove }) => {
+    if (expectedChance >= 1.0) {
+      return; // chance=1.0 のものはスキップ
+    }
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(randomAbove);
+    const result = await effect.onHit!(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
+
+  it.each(cases)('$name はほのおタイプには付与しない', async ({ effect, randomBelow }) => {
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext('ほのお');
+
+    jest.spyOn(Math, 'random').mockReturnValue(randomBelow);
+    const result = await effect.onHit!(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/pyro-ball-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/pyro-ball-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「かえんボール」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にやけどを付与 (Has a 10% chance to burn the target)
+ */
+export class PyroBallEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sacred-fire-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sacred-fire-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「せいなるほのお」の特殊効果実装
+ *
+ * 効果: 50%の確率で相手にやけどを付与 (Has a 50% chance to burn the target)
+ * 注: 自分のこおり状態を解除する効果は別処理（バトルフロー）で扱う
+ */
+export class SacredFireEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Burn;
+  protected readonly chance = 0.5;
+  protected readonly immuneTypes = ['ほのお'];
+  protected readonly message = 'was burned!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -53,6 +53,12 @@ import { SparklingAriaEffect } from './effects/sparkling-aria-effect';
 import { ScorchingSandsEffect } from './effects/scorching-sands-effect';
 import { WillOWispEffect } from './effects/will-o-wisp-effect';
 import { RefreshEffect } from './effects/refresh-effect';
+import { FirePunchEffect } from './effects/fire-punch-effect';
+import { FlameWheelEffect } from './effects/flame-wheel-effect';
+import { SacredFireEffect } from './effects/sacred-fire-effect';
+import { BlazeKickEffect } from './effects/blaze-kick-effect';
+import { FlareBlitzEffect } from './effects/flare-blitz-effect';
+import { PyroBallEffect } from './effects/pyro-ball-effect';
 
 /**
  * 技のレジストリ
@@ -137,6 +143,13 @@ export class MoveRegistry {
       // やけど付与系の変化技（Issue #116）
       this.registry.set('おにび', new WillOWispEffect());
       this.registry.set('リフレッシュ', new RefreshEffect());
+      // 物理カテゴリやけど付与系（Issue #123）
+      this.registry.set('ほのおのパンチ', new FirePunchEffect());
+      this.registry.set('かえんぐるま', new FlameWheelEffect());
+      this.registry.set('せいなるほのお', new SacredFireEffect());
+      this.registry.set('ブレイズキック', new BlazeKickEffect());
+      this.registry.set('フレアドライブ', new FlareBlitzEffect());
+      this.registry.set('かえんボール', new PyroBallEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #123「物理カテゴリの未実装技の特殊効果: やけど付与 (8件)」のうち **6件を実装**。残る `からげんき` と `くちばしキャノン` はエンジン未整備のため保留（詳細下記）。

### 実装した技（6件）
| 技 | 効果 |
|---|---|
| ほのおのパンチ | 10% やけど |
| かえんぐるま | 10% やけど（自己解凍は別処理） |
| せいなるほのお | 50% やけど（自己解凍は別処理） |
| ブレイズキック | 10% やけど（急所率上昇は別処理） |
| フレアドライブ | 10% やけど（反動ダメージは Issue #127 で扱う） |
| かえんボール | 10% やけど |

いずれも `BaseStatusConditionEffect` を継承するシンプルな構成。先行する Issue #93 の `ScaldEffect`／`IceBurnEffect` 等が「やけど付与以外の効果は別処理」と明記している前例に従い、本 PR では「やけど付与」のみを実装。

### 保留した技（2件）
- **からげんき (Facade)**: 「自分が状態異常時に威力2倍」。やけど付与ではなく `move.power` の動的修正が必要。`IMoveEffect.beforeDamage` は現状 `void` を返すのみで威力修正のフックがなく、`BattleContext` にも `powerMultiplier` 系のフィールドが存在しない。**エンジン拡張が前提**。
- **くちばしキャノン (Beak Blast)**: 「チャージターン中に接触してきた相手をやけど」。2ターンチャージ・接触反応のフックが未整備（既存 `IceBurn` のチャージ注記と同じ理由）。

→ 上記2件は別 Issue を分けて切るのが望ましいです（必要であれば本 PR マージ後にフォローアップ Issue を作成可）。

## Test plan
- [x] `physical-burn-effects.spec.ts` 追加: 6件×3観点（確率内付与 / 確率外スキップ / ほのおタイプ免疫）= 18 ケース
- [x] `npm test`: 120 suites / 708 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #123