### PR TITLE
feat: 物理カテゴリこおり付与の技効果を追加 (Issue #124)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/ice-punch-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/ice-punch-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「れいとうパンチ」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手をこおりにする (Has a 10% chance to freeze the target)
+ */
+export class IcePunchEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Freeze;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['こおり'];
+  protected readonly message = 'was frozen solid!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -59,6 +59,7 @@ import { SacredFireEffect } from './effects/sacred-fire-effect';
 import { BlazeKickEffect } from './effects/blaze-kick-effect';
 import { FlareBlitzEffect } from './effects/flare-blitz-effect';
 import { PyroBallEffect } from './effects/pyro-ball-effect';
+import { IcePunchEffect } from './effects/ice-punch-effect';
 
 /**
  * 技のレジストリ
@@ -150,6 +151,8 @@ export class MoveRegistry {
       this.registry.set('ブレイズキック', new BlazeKickEffect());
       this.registry.set('フレアドライブ', new FlareBlitzEffect());
       this.registry.set('かえんボール', new PyroBallEffect());
+      // 物理カテゴリこおり付与系（Issue #124）
+      this.registry.set('れいとうパンチ', new IcePunchEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #124「物理カテゴリの未実装技の特殊効果: こおり付与 (1件)」を実装。

| 技 | 効果 |
|---|---|
| れいとうパンチ | 10% の確率で相手をこおりにする |

`BaseStatusConditionEffect` を継承するシンプルな構成（既存の `IceBeamEffect` と同じパターン）。

## Test plan
- [x] `npm test`: 119 suites / 690 tests Pass（既存の `BaseStatusConditionEffect` テストで網羅済み、`IceBeamEffect` と同じ前例に従い個別 spec は追加せず）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #124