### PR TITLE
feat: 物理カテゴリねむり関連の技効果を追加 (Issue #130)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/wake-up-slap-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/wake-up-slap-effect.spec.ts
@@ -1,0 +1,84 @@
+import { WakeUpSlapEffect } from './wake-up-slap-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('WakeUpSlapEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('眠り中の相手のねむり状態を解除する', async () => {
+    const effect = new WakeUpSlapEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, statusCondition: StatusCondition.Sleep });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe('target woke up!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it.each([
+    ['やけど', StatusCondition.Burn],
+    ['まひ', StatusCondition.Paralysis],
+    ['どく', StatusCondition.Poison],
+    ['こおり', StatusCondition.Freeze],
+    [null, null],
+  ])('眠り以外の状態（%s）では何もしない', async (_label, condition) => {
+    const effect = new WakeUpSlapEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, statusCondition: condition });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は null を返す', async () => {
+    const effect = new WakeUpSlapEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, statusCondition: StatusCondition.Sleep });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/wake-up-slap-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/wake-up-slap-effect.ts
@@ -1,0 +1,33 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「めざましビンタ」の特殊効果実装
+ *
+ * 効果: 相手が眠り状態のときに命中させると相手の眠り状態を解除する
+ * 注: 相手が眠り状態のときに威力が2倍になる効果は、技の威力を動的に修正する
+ *     仕組みが未整備なため別処理（ダメージ計算側）で扱う
+ */
+export class WakeUpSlapEffect implements IMoveEffect {
+  async onHit(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    if (defender.statusCondition !== StatusCondition.Sleep) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      statusCondition: StatusCondition.None,
+    });
+
+    return 'target woke up!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -60,6 +60,7 @@ import { BlazeKickEffect } from './effects/blaze-kick-effect';
 import { FlareBlitzEffect } from './effects/flare-blitz-effect';
 import { PyroBallEffect } from './effects/pyro-ball-effect';
 import { IcePunchEffect } from './effects/ice-punch-effect';
+import { WakeUpSlapEffect } from './effects/wake-up-slap-effect';
 
 /**
  * 技のレジストリ
@@ -153,6 +154,8 @@ export class MoveRegistry {
       this.registry.set('かえんボール', new PyroBallEffect());
       // 物理カテゴリこおり付与系（Issue #124）
       this.registry.set('れいとうパンチ', new IcePunchEffect());
+      // 物理カテゴリねむり関連（Issue #130）
+      this.registry.set('めざましビンタ', new WakeUpSlapEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #130「物理カテゴリの未実装技の特殊効果: ねむり付与 (1件)」を実装。

| 技 | 実装した効果 |
|---|---|
| めざましビンタ | 眠っている相手に命中するとねむり状態を解除する |

### 設計メモ
- 名前は「ねむり付与」だが、実態は「眠っている相手を起こす」効果。Issue 生成側のカテゴライズの問題と考えられる
- 既存の `SparklingAriaEffect`（相手のやけどを治す）と同じ「相手の状態異常を解除する」`onHit` パターンで実装
- **保留**: 「相手が眠っている場合に威力2倍」は、技の威力を動的に修正する仕組み（power-modifier API）が未整備のため別処理（ダメージ計算側）に委ねる旨をコード内コメントに明記

## Test plan
- [x] `wake-up-slap-effect.spec.ts` 追加: 7ケース（眠り→起こす / 他状態異常スキップ×4 / null スキップ / battleRepo 無し）
- [x] `npm test`: 120 suites / 698 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #130