### PR TITLE
feat: 特殊カテゴリこおり付与の技効果を追加 (Issue #95)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/blizzard-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/blizzard-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ふぶき」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手をこおりにする (Has a 10% chance to freeze the target)
+ */
+export class BlizzardEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Freeze;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['こおり'];
+  protected readonly message = 'was frozen solid!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/powder-snow-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/powder-snow-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「こなゆき」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手をこおりにする (Has a 10% chance to freeze the target)
+ */
+export class PowderSnowEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Freeze;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['こおり'];
+  protected readonly message = 'was frozen solid!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -61,6 +61,8 @@ import { FlareBlitzEffect } from './effects/flare-blitz-effect';
 import { PyroBallEffect } from './effects/pyro-ball-effect';
 import { IcePunchEffect } from './effects/ice-punch-effect';
 import { WakeUpSlapEffect } from './effects/wake-up-slap-effect';
+import { BlizzardEffect } from './effects/blizzard-effect';
+import { PowderSnowEffect } from './effects/powder-snow-effect';
 
 /**
  * 技のレジストリ
@@ -156,6 +158,9 @@ export class MoveRegistry {
       this.registry.set('れいとうパンチ', new IcePunchEffect());
       // 物理カテゴリねむり関連（Issue #130）
       this.registry.set('めざましビンタ', new WakeUpSlapEffect());
+      // 特殊カテゴリこおり付与系（Issue #95）
+      this.registry.set('ふぶき', new BlizzardEffect());
+      this.registry.set('こなゆき', new PowderSnowEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #95「特殊カテゴリの未実装技の特殊効果: こおり付与 (2件)」を実装。

| 技 | 効果 |
|---|---|
| ふぶき | 10% の確率で相手をこおりにする |
| こなゆき | 10% の確率で相手をこおりにする |

いずれも `BaseStatusConditionEffect` 継承（既存 `IceBeamEffect` / `IcePunchEffect`（#124）と同じパターン）。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass（`BaseStatusConditionEffect` の既存テストで網羅、簡易拡張のため個別 spec は #93 系の前例に従い割愛）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #95