### PR TITLE
feat: 特殊カテゴリひるみ付与の技効果を追加 (Issue #98)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/dark-pulse-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/dark-pulse-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「あくのはどう」の特殊効果実装
+ *
+ * 効果: 20%の確率で相手にひるみを付与 (Has a 20% chance to make the target flinch)
+ */
+export class DarkPulseEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/extrasensory-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/extrasensory-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「じんつうりき」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にひるみを付与 (Has a 10% chance to make the target flinch)
+ */
+export class ExtrasensoryEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/twister-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/twister-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「たつまき」の特殊効果実装
+ *
+ * 効果: 20%の確率で相手にひるみを付与 (Has a 20% chance to make the target flinch)
+ */
+export class TwisterEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -63,6 +63,9 @@ import { IcePunchEffect } from './effects/ice-punch-effect';
 import { WakeUpSlapEffect } from './effects/wake-up-slap-effect';
 import { BlizzardEffect } from './effects/blizzard-effect';
 import { PowderSnowEffect } from './effects/powder-snow-effect';
+import { TwisterEffect } from './effects/twister-effect';
+import { ExtrasensoryEffect } from './effects/extrasensory-effect';
+import { DarkPulseEffect } from './effects/dark-pulse-effect';
 
 /**
  * 技のレジストリ
@@ -161,6 +164,10 @@ export class MoveRegistry {
       // 特殊カテゴリこおり付与系（Issue #95）
       this.registry.set('ふぶき', new BlizzardEffect());
       this.registry.set('こなゆき', new PowderSnowEffect());
+      // 特殊カテゴリひるみ付与系（Issue #98）
+      this.registry.set('たつまき', new TwisterEffect());
+      this.registry.set('じんつうりき', new ExtrasensoryEffect());
+      this.registry.set('あくのはどう', new DarkPulseEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #98「特殊カテゴリの未実装技の特殊効果: ひるみ付与 (3件)」を実装。

| 技 | 効果 |
|---|---|
| たつまき | 20% の確率で相手にひるみを付与 |
| じんつうりき | 10% の確率で相手にひるみを付与 |
| あくのはどう | 20% の確率で相手にひるみを付与 |

いずれも `BaseStatusConditionEffect` 継承（既存 `AirSlashEffect` と同じパターン）。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例（AirSlash / Ember 等）に従い割愛。`BaseStatusConditionEffect` の既存テストで網羅。

Closes #98