### PR TITLE
feat: 特殊カテゴリねむり関連の技効果を追加 (Issue #97)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/relic-song-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/relic-song-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「いにしえのうた」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手をねむりにする (Has a 10% chance to put the target to sleep)
+ */
+export class RelicSongEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/snore-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/snore-effect.spec.ts
@@ -1,0 +1,103 @@
+import { SnoreEffect } from './snore-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('SnoreEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockTrainedPokemonRepository = {
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        pokemon: { id: 1, primaryType: { name: 'ノーマル' }, secondaryType: null },
+        ability: null,
+      }),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+      trainedPokemonRepository:
+        mockTrainedPokemonRepository as unknown as BattleContext['trainedPokemonRepository'],
+    };
+  };
+
+  it('使用者が眠っているときは30%でひるみを付与する', async () => {
+    const effect = new SnoreEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: StatusCondition.Sleep });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.1); // 30% を通過
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe('flinched!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Flinch,
+    });
+
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['null', null],
+    ['やけど', StatusCondition.Burn],
+    ['まひ', StatusCondition.Paralysis],
+    ['こおり', StatusCondition.Freeze],
+  ])('使用者が眠っていない（%s）ときは発動しない', async (_label, condition) => {
+    const effect = new SnoreEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: condition });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+
+  it('使用者が眠っていても30%を外したら付与しない', async () => {
+    const effect = new SnoreEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: StatusCondition.Sleep });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.5); // 30% を外す
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/snore-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/snore-effect.ts
@@ -1,0 +1,32 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「いびき」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にひるみを付与 (Has a 30% chance to make the target flinch)
+ * 制約: 使用者が「ねむり」状態のときのみ発動する
+ *
+ * 注: 「使用者が眠っていないとそもそも技が発動しない（ダメージも与えない）」という
+ *     完全な仕様は、現状の `IMoveEffect` には事前判定フックがないため対応不可。
+ *     ここでは「ひるみ付与」効果のみを使用者眠り条件でガードする。
+ */
+export class SnoreEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+
+  override async onHit(
+    attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (attacker.statusCondition !== StatusCondition.Sleep) {
+      return null;
+    }
+    return super.onHit(attacker, defender, battleContext);
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -66,6 +66,8 @@ import { PowderSnowEffect } from './effects/powder-snow-effect';
 import { TwisterEffect } from './effects/twister-effect';
 import { ExtrasensoryEffect } from './effects/extrasensory-effect';
 import { DarkPulseEffect } from './effects/dark-pulse-effect';
+import { RelicSongEffect } from './effects/relic-song-effect';
+import { SnoreEffect } from './effects/snore-effect';
 
 /**
  * 技のレジストリ
@@ -168,6 +170,9 @@ export class MoveRegistry {
       this.registry.set('たつまき', new TwisterEffect());
       this.registry.set('じんつうりき', new ExtrasensoryEffect());
       this.registry.set('あくのはどう', new DarkPulseEffect());
+      // 特殊カテゴリねむり関連（Issue #97）
+      this.registry.set('いにしえのうた', new RelicSongEffect());
+      this.registry.set('いびき', new SnoreEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #97「特殊カテゴリの未実装技の特殊効果: ねむり付与 (4件)」のうち **2件を実装**。残る `ゆめくい` / `さわぐ` は engine 未整備のため保留。

### 実装した技（2件）
| 技 | 効果 |
|---|---|
| いにしえのうた | 10% の確率で相手をねむりにする |
| いびき | 使用者が眠り状態のときに 30% でひるみ付与 |

- いにしえのうた: 既存の `SleepPowderEffect` と同じ `BaseStatusConditionEffect` パターン
- いびき: `BaseStatusConditionEffect` を継承し、`onHit` を override して「使用者が眠り状態」を事前ガード。`super.onHit` 委譲で重複ロジックを避ける

### 保留した技（2件）
- **ゆめくい (Dream Eater)**: 「相手が眠っているときのみ命中・与えダメージの 1/2 を HP 回復」
  - 事前ガード（相手の状態によって技自体を無効化）と HP ドレインの両方が必要
  - 現状 `IMoveEffect` には pre-hit gating フックも HP-drain ヘルパも存在しないため見送り
- **さわぐ (Uproar)**: 「複数ターン強制使用 + その間自分・相手が眠り不可」
  - マルチターンロック（move-locking）の仕組みが engine 未整備のため見送り

→ 上記2件はエンジン側で必要な仕組み（pre-hit gate / drain / lock-in / sleep-prevention aura）の Issue 化を推奨。

## Test plan
- [x] `snore-effect.spec.ts` 追加: 6ケース（使用者眠り×確率内/外、使用者非眠り4状態、確率外しスキップ）
- [x] `npm test`: 120 suites / 697 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #97