### PR TITLE
feat: 特殊カテゴリまひ付与の技効果を追加 (Issue #94)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/discharge-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/discharge-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ほうでん」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class DischargeEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/dragon-breath-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/dragon-breath-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「りゅうのいぶき」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class DragonBreathEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/stoked-sparksurfer-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/stoked-sparksurfer-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ライトニングサーフライド」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Has a 100% chance to paralyze the target)
+ */
+export class StokedSparksurferEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/zap-cannon-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/zap-cannon-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「でんじほう」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Has a 100% chance to paralyze the target)
+ */
+export class ZapCannonEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -68,6 +68,10 @@ import { ExtrasensoryEffect } from './effects/extrasensory-effect';
 import { DarkPulseEffect } from './effects/dark-pulse-effect';
 import { RelicSongEffect } from './effects/relic-song-effect';
 import { SnoreEffect } from './effects/snore-effect';
+import { ZapCannonEffect } from './effects/zap-cannon-effect';
+import { DragonBreathEffect } from './effects/dragon-breath-effect';
+import { DischargeEffect } from './effects/discharge-effect';
+import { StokedSparksurferEffect } from './effects/stoked-sparksurfer-effect';
 
 /**
  * 技のレジストリ
@@ -173,6 +177,11 @@ export class MoveRegistry {
       // 特殊カテゴリねむり関連（Issue #97）
       this.registry.set('いにしえのうた', new RelicSongEffect());
       this.registry.set('いびき', new SnoreEffect());
+      // 特殊カテゴリまひ付与系（Issue #94）
+      this.registry.set('でんじほう', new ZapCannonEffect());
+      this.registry.set('りゅうのいぶき', new DragonBreathEffect());
+      this.registry.set('ほうでん', new DischargeEffect());
+      this.registry.set('ライトニングサーフライド', new StokedSparksurferEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #94「特殊カテゴリの未実装技の特殊効果: まひ付与 (5件)」のうち **4件を実装**。`10まんボルト` は既存の `ThunderboltEffect` が登録済みのためスキップ。

| 技 | 効果 |
|---|---|
| でんじほう | 100% まひ |
| りゅうのいぶき | 30% まひ |
| ほうでん | 30% まひ |
| ライトニングサーフライド | 100% まひ |

いずれも `BaseStatusConditionEffect` 継承。でんきタイプは Gen6+ 仕様でまひ免疫。

### 注
Issue 本文の `１０まんボルト`（全角数字）は既存登録 `10まんボルト`（半角数字）と同一の `Thunderbolt` を指していると判断。Issue 生成側の表記揺れと思われる。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛（`BaseStatusConditionEffect` の既存テストで網羅）。

Closes #94