### PR TITLE
feat: 特殊カテゴリどく付与の技効果を追加 (Issue #96)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/sludge-bomb-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sludge-bomb-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ヘドロばくだん」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にどくを付与 (Has a 30% chance to poison the target)
+ */
+export class SludgeBombEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sludge-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sludge-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ヘドロこうげき」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にどくを付与 (Has a 30% chance to poison the target)
+ */
+export class SludgeEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sludge-wave-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sludge-wave-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ヘドロウェーブ」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にどくを付与 (Has a 10% chance to poison the target)
+ */
+export class SludgeWaveEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/smog-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/smog-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「スモッグ」の特殊効果実装
+ *
+ * 効果: 40%の確率で相手にどくを付与 (Has a 40% chance to poison the target)
+ */
+export class SmogEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.4;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -72,6 +72,10 @@ import { ZapCannonEffect } from './effects/zap-cannon-effect';
 import { DragonBreathEffect } from './effects/dragon-breath-effect';
 import { DischargeEffect } from './effects/discharge-effect';
 import { StokedSparksurferEffect } from './effects/stoked-sparksurfer-effect';
+import { SmogEffect } from './effects/smog-effect';
+import { SludgeEffect } from './effects/sludge-effect';
+import { SludgeBombEffect } from './effects/sludge-bomb-effect';
+import { SludgeWaveEffect } from './effects/sludge-wave-effect';
 
 /**
  * 技のレジストリ
@@ -182,6 +186,11 @@ export class MoveRegistry {
       this.registry.set('りゅうのいぶき', new DragonBreathEffect());
       this.registry.set('ほうでん', new DischargeEffect());
       this.registry.set('ライトニングサーフライド', new StokedSparksurferEffect());
+      // 特殊カテゴリどく付与系（Issue #96）
+      this.registry.set('スモッグ', new SmogEffect());
+      this.registry.set('ヘドロこうげき', new SludgeEffect());
+      this.registry.set('ヘドロばくだん', new SludgeBombEffect());
+      this.registry.set('ヘドロウェーブ', new SludgeWaveEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #96「特殊カテゴリの未実装技の特殊効果: どく付与 (5件)」のうち **4件を実装**。`ベノムショック` は power-modifier 未整備のため保留。

| 技 | 効果 |
|---|---|
| スモッグ | 40% どく |
| ヘドロこうげき | 30% どく |
| ヘドロばくだん | 30% どく |
| ヘドロウェーブ | 10% どく |

いずれも `BaseStatusConditionEffect` 継承（既存 `ToxicEffect` と同じパターン）。どく・はがねタイプには免疫。

### 保留した技
- **ベノムショック (Venoshock)**: 「相手が毒状態なら威力2倍」。`からげんき`（#123）と同じく、power-modifier API が未整備のため見送り。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。

Refs #96