### PR TITLE
feat: 変化カテゴリまひ付与の技効果を追加 (Issue #109)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/glare-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/glare-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「へびにらみ」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Paralyzes the target)
+ */
+export class GlareEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/stun-spore-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/stun-spore-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「しびれごな」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Paralyzes the target)
+ * 制約: 粉技のためくさタイプには無効
+ */
+export class StunSporeEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき', 'くさ'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/thunder-wave-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/thunder-wave-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「でんじは」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Paralyzes the target)
+ * 注: じめんタイプへの無効化（タイプ相性）はダメージ計算/命中判定側で扱う想定
+ */
+export class ThunderWaveEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -76,6 +76,9 @@ import { SmogEffect } from './effects/smog-effect';
 import { SludgeEffect } from './effects/sludge-effect';
 import { SludgeBombEffect } from './effects/sludge-bomb-effect';
 import { SludgeWaveEffect } from './effects/sludge-wave-effect';
+import { StunSporeEffect } from './effects/stun-spore-effect';
+import { ThunderWaveEffect } from './effects/thunder-wave-effect';
+import { GlareEffect } from './effects/glare-effect';
 
 /**
  * 技のレジストリ
@@ -191,6 +194,10 @@ export class MoveRegistry {
       this.registry.set('ヘドロこうげき', new SludgeEffect());
       this.registry.set('ヘドロばくだん', new SludgeBombEffect());
       this.registry.set('ヘドロウェーブ', new SludgeWaveEffect());
+      // 変化カテゴリまひ付与系（Issue #109）
+      this.registry.set('しびれごな', new StunSporeEffect());
+      this.registry.set('でんじは', new ThunderWaveEffect());
+      this.registry.set('へびにらみ', new GlareEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #109「変化カテゴリの未実装技の特殊効果: まひ付与 (3件)」を実装。

| 技 | 効果 |
|---|---|
| しびれごな | 必ずまひ付与（粉技、くさタイプ免疫） |
| でんじは | 必ずまひ付与 |
| へびにらみ | 必ずまひ付与 |

いずれも `BaseStatusConditionEffect` 継承で `chance=1.0`。でんきタイプは Gen6+ 仕様でまひ免疫。
- しびれごな: 粉技のためくさタイプにも免疫を付与（既存 `SleepPowderEffect` と同パターン）
- でんじは: じめんタイプへの技自体の無効化（タイプ相性）は別処理（ダメージ計算/命中側）

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。

Closes #109