### PR TITLE
feat: 変化カテゴリどく付与の技効果を追加 (Issue #108)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/poison-gas-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-gas-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくガス」の特殊効果実装
+ *
+ * 効果: 必ず相手にどくを付与 (Poisons the target)
+ */
+export class PoisonGasEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/poison-powder-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-powder-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくのこな」の特殊効果実装
+ *
+ * 効果: 必ず相手にどくを付与 (Poisons the target)
+ * 制約: 粉技のためくさタイプには無効
+ */
+export class PoisonPowderEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['どく', 'はがね', 'くさ'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/toxic-thread-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/toxic-thread-effect.spec.ts
@@ -1,0 +1,144 @@
+import { ToxicThreadEffect } from './toxic-thread-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('ToxicThreadEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (overrides?: {
+    defenderPrimaryType?: string;
+    defenderSecondaryType?: string | null;
+  }): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockTrainedPokemonRepository = {
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        pokemon: {
+          id: 1,
+          primaryType: { name: overrides?.defenderPrimaryType ?? 'むし' },
+          secondaryType:
+            overrides?.defenderSecondaryType !== undefined
+              ? overrides.defenderSecondaryType
+                ? { name: overrides.defenderSecondaryType }
+                : null
+              : null,
+        },
+        ability: null,
+      }),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+      trainedPokemonRepository:
+        mockTrainedPokemonRepository as unknown as BattleContext['trainedPokemonRepository'],
+    };
+  };
+
+  it('どくを付与しすばやさを1段階下げる', async () => {
+    const effect = new ToxicThreadEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('was poisoned! Speed fell!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Poison,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      speedRank: -1,
+    });
+  });
+
+  it.each([
+    ['どく', 'どく'],
+    ['はがね', 'はがね'],
+  ])('%sタイプにはどくを付与せず、すばやさのみ下げる', async (_label, typeName) => {
+    const effect = new ToxicThreadEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext({ defenderPrimaryType: typeName });
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('Speed fell!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Poison,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      speedRank: -1,
+    });
+  });
+
+  it('既に状態異常がある場合はどくを付与せず、すばやさのみ下げる', async () => {
+    const effect = new ToxicThreadEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, statusCondition: StatusCondition.Burn });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('Speed fell!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Poison,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      speedRank: -1,
+    });
+  });
+
+  it('すばやさが既に -6 のときは下げない（どくのみ付与）', async () => {
+    const effect = new ToxicThreadEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, speedRank: -6 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('was poisoned!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Poison,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalledWith(defender.id, {
+      speedRank: expect.any(Number),
+    });
+  });
+
+  it('battleRepository が無い場合は null', async () => {
+    const effect = new ToxicThreadEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/toxic-thread-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/toxic-thread-effect.ts
@@ -1,0 +1,71 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくのいと」の特殊効果実装
+ *
+ * 効果: 相手にどくを付与し、すばやさランクを1段階下げる
+ *       (Poisons the target and lowers its Speed by one stage)
+ *
+ * - どくタイプ・はがねタイプにはどく付与は無効
+ * - すばやさランクは状態異常付与の成否にかかわらず常に下げを試みる
+ */
+export class ToxicThreadEffect implements IMoveEffect {
+  private static readonly POISON_IMMUNE_TYPES = ['どく', 'はがね'] as const;
+
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const messages: string[] = [];
+
+    // どく付与の試行
+    const canPoison =
+      (!defender.statusCondition || defender.statusCondition === StatusCondition.None) &&
+      !(await this.hasPoisonImmuneType(defender, battleContext));
+
+    if (canPoison) {
+      await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+        statusCondition: StatusCondition.Poison,
+      });
+      messages.push('was poisoned!');
+    }
+
+    // すばやさランク -1 の試行
+    const currentSpeedRank = defender.getStatRank('speed');
+    const newSpeedRank = Math.max(-6, currentSpeedRank - 1);
+    if (newSpeedRank !== currentSpeedRank) {
+      await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+        speedRank: newSpeedRank,
+      });
+      messages.push('Speed fell!');
+    }
+
+    return messages.length > 0 ? messages.join(' ') : null;
+  }
+
+  private async hasPoisonImmuneType(
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<boolean> {
+    if (!battleContext.trainedPokemonRepository) {
+      return false;
+    }
+    const trainedPokemon = await battleContext.trainedPokemonRepository.findById(
+      defender.trainedPokemonId,
+    );
+    if (!trainedPokemon) {
+      return false;
+    }
+    const primary = trainedPokemon.pokemon.primaryType.name;
+    const secondary = trainedPokemon.pokemon.secondaryType?.name;
+    return ToxicThreadEffect.POISON_IMMUNE_TYPES.some(t => t === primary || t === secondary);
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -79,6 +79,9 @@ import { SludgeWaveEffect } from './effects/sludge-wave-effect';
 import { StunSporeEffect } from './effects/stun-spore-effect';
 import { ThunderWaveEffect } from './effects/thunder-wave-effect';
 import { GlareEffect } from './effects/glare-effect';
+import { PoisonPowderEffect } from './effects/poison-powder-effect';
+import { PoisonGasEffect } from './effects/poison-gas-effect';
+import { ToxicThreadEffect } from './effects/toxic-thread-effect';
 
 /**
  * 技のレジストリ
@@ -198,6 +201,10 @@ export class MoveRegistry {
       this.registry.set('しびれごな', new StunSporeEffect());
       this.registry.set('でんじは', new ThunderWaveEffect());
       this.registry.set('へびにらみ', new GlareEffect());
+      // 変化カテゴリどく付与系（Issue #108）
+      this.registry.set('どくのこな', new PoisonPowderEffect());
+      this.registry.set('どくガス', new PoisonGasEffect());
+      this.registry.set('どくのいと', new ToxicThreadEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #108「変化カテゴリの未実装技の特殊効果: どく付与 (6件)」のうち **3件を実装**。残る3件は engine 未整備で保留。

### 実装した技
| 技 | 効果 |
|---|---|
| どくのこな | 必ずどく付与（粉技、くさタイプ免疫） |
| どくガス | 必ずどく付与 |
| どくのいと | どく付与 + すばやさを1段階下げる |

- どくのこな・どくガス: 既存 `ToxicEffect` と同じ `BaseStatusConditionEffect` パターン
- どくのいと: 既存 base にぴったり合うものがないためカスタム `IMoveEffect`。どく付与とすばやさダウンは独立して試行され、片方失敗してももう片方は実行される（本家挙動に合わせる）

### 保留した技（3件）
- **どくびし (Toxic Spikes)**: フィールド設置型のハザード。`Battle` エンティティ側に「ハザードリスト」「交代時フック」の仕組みが必要。engine 拡張が前提
- **ベノムトラップ (Venom Drench)**: 「相手が毒のときのみ攻撃/特攻/素早さ -1」。pre-hit gating + multi-stat decrease。事前ガードフックが未整備
- **トーチカ (Baneful Bunker)**: まもり相当 + 接触時どく。protect mechanism と contact-reaction の両方が engine 未整備

→ それぞれ別 Issue 化（ハザード API、pre-hit gate API、protect/contact-reaction API）を推奨

## Test plan
- [x] `toxic-thread-effect.spec.ts` 追加: 6ケース（どく+速度↓ / どくタイプ・はがねタイプ・既存状態異常時はどく不発・速度のみ / 速度-6時はどくのみ / リポジトリ無し）
- [x] `npm test`: 120 suites / 697 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #108