### PR TITLE
feat: 変化カテゴリこんらん付与の技効果を追加 (Issue #105)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/base/base-confuse-with-stat-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-confuse-with-stat-boost-effect.spec.ts
@@ -1,0 +1,129 @@
+import { BaseConfuseWithStatBoostEffect } from './base-confuse-with-stat-boost-effect';
+import { StatType } from './base-stat-change-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestSwaggerLike extends BaseConfuseWithStatBoostEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = 2;
+}
+
+class TestFlatterLike extends BaseConfuseWithStatBoostEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = 1;
+}
+
+describe('BaseConfuseWithStatBoostEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  describe('Swagger 相当（Attack +2 + こんらん）', () => {
+    it('攻撃を+2上げてこんらんを付与する', async () => {
+      const effect = new TestSwaggerLike();
+      const attacker = createBattlePokemonStatus();
+      const defender = createBattlePokemonStatus({ id: 2 });
+      const ctx = createBattleContext();
+
+      const result = await effect.onUse(attacker, defender, ctx);
+
+      expect(result).toBe('Attack rose! became confused!');
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        attackRank: 2,
+      });
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        statusCondition: StatusCondition.Confusion,
+      });
+    });
+
+    it('攻撃ランクが上限の場合はランク変化メッセージなしでこんらんのみ付与', async () => {
+      const effect = new TestSwaggerLike();
+      const attacker = createBattlePokemonStatus();
+      const defender = createBattlePokemonStatus({ id: 2, attackRank: 6 });
+      const ctx = createBattleContext();
+
+      const result = await effect.onUse(attacker, defender, ctx);
+
+      expect(result).toBe('became confused!');
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        statusCondition: StatusCondition.Confusion,
+      });
+    });
+
+    it('既に状態異常がある場合は能力上昇のみ実行', async () => {
+      const effect = new TestSwaggerLike();
+      const attacker = createBattlePokemonStatus();
+      const defender = createBattlePokemonStatus({
+        id: 2,
+        statusCondition: StatusCondition.Burn,
+      });
+      const ctx = createBattleContext();
+
+      const result = await effect.onUse(attacker, defender, ctx);
+
+      expect(result).toBe('Attack rose!');
+    });
+  });
+
+  describe('Flatter 相当（Special Attack +1 + こんらん）', () => {
+    it('特攻を+1上げてこんらんを付与する', async () => {
+      const effect = new TestFlatterLike();
+      const attacker = createBattlePokemonStatus();
+      const defender = createBattlePokemonStatus({ id: 2 });
+      const ctx = createBattleContext();
+
+      const result = await effect.onUse(attacker, defender, ctx);
+
+      expect(result).toBe('Special Attack rose! became confused!');
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        specialAttackRank: 1,
+      });
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        statusCondition: StatusCondition.Confusion,
+      });
+    });
+  });
+
+  it('battleRepository が無い場合は null', async () => {
+    const effect = new TestSwaggerLike();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-confuse-with-stat-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-confuse-with-stat-boost-effect.ts
@@ -1,0 +1,54 @@
+import { IMoveEffect } from '../../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { StatType, STAT_RANK_PROP_MAP, STAT_NAME_MAP } from './base-stat-change-effect';
+
+/**
+ * 「相手の能力を上げつつこんらんにする」変化技の基底クラス
+ *
+ * 例: いばる（攻撃 +2 + こんらん）、おだてる（特攻 +1 + こんらん）
+ *
+ * - 能力ランクとこんらん付与は独立して試行される
+ *   片方が失敗してももう片方は実行される（本家挙動）
+ * - こんらん付与は既に状態異常がある場合はスキップ（エンジン上 statusCondition が単一スロットのため）
+ */
+export abstract class BaseConfuseWithStatBoostEffect implements IMoveEffect {
+  protected abstract readonly statType: StatType;
+  protected abstract readonly rankChange: number;
+
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const messages: string[] = [];
+
+    // 能力ランク変更
+    const currentRank = defender.getStatRank(this.statType);
+    const newRank = Math.max(-6, Math.min(6, currentRank + this.rankChange));
+    if (newRank !== currentRank) {
+      const propName = STAT_RANK_PROP_MAP[this.statType];
+      await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+        [propName]: newRank,
+      } as Partial<BattlePokemonStatus>);
+      const statName = STAT_NAME_MAP[this.statType];
+      const direction = this.rankChange > 0 ? 'rose' : 'fell';
+      messages.push(`${statName} ${direction}!`);
+    }
+
+    // こんらん付与
+    if (!defender.statusCondition || defender.statusCondition === StatusCondition.None) {
+      await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+        statusCondition: StatusCondition.Confusion,
+      });
+      messages.push('became confused!');
+    }
+
+    return messages.length > 0 ? messages.join(' ') : null;
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/confuse-ray-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/confuse-ray-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「あやしいひかり」の特殊効果実装
+ *
+ * 効果: 必ず相手をこんらんにする (Confuses the target)
+ */
+export class ConfuseRayEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Confusion;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'became confused!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/flatter-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/flatter-effect.ts
@@ -1,0 +1,12 @@
+import { BaseConfuseWithStatBoostEffect } from './base/base-confuse-with-stat-boost-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「おだてる」の特殊効果実装
+ *
+ * 効果: 相手の特攻ランクを1段階上げ、こんらん状態にする
+ */
+export class FlatterEffect extends BaseConfuseWithStatBoostEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/supersonic-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/supersonic-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ちょうおんぱ」の特殊効果実装
+ *
+ * 効果: 必ず相手をこんらんにする (Confuses the target)
+ */
+export class SupersonicEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Confusion;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'became confused!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/swagger-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/swagger-effect.ts
@@ -1,0 +1,12 @@
+import { BaseConfuseWithStatBoostEffect } from './base/base-confuse-with-stat-boost-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「いばる」の特殊効果実装
+ *
+ * 効果: 相手の攻撃ランクを2段階上げ、こんらん状態にする
+ */
+export class SwaggerEffect extends BaseConfuseWithStatBoostEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sweet-kiss-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sweet-kiss-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「てんしのキッス」の特殊効果実装
+ *
+ * 効果: 必ず相手をこんらんにする (Confuses the target)
+ */
+export class SweetKissEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Confusion;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'became confused!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/teeter-dance-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/teeter-dance-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「フラフラダンス」の特殊効果実装
+ *
+ * 効果: 必ず相手をこんらんにする (Confuses the target)
+ * 注: 本来は場のすべてのポケモンを対象とするが、現状は単体対象として実装
+ */
+export class TeeterDanceEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Confusion;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'became confused!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -82,6 +82,12 @@ import { GlareEffect } from './effects/glare-effect';
 import { PoisonPowderEffect } from './effects/poison-powder-effect';
 import { PoisonGasEffect } from './effects/poison-gas-effect';
 import { ToxicThreadEffect } from './effects/toxic-thread-effect';
+import { SupersonicEffect } from './effects/supersonic-effect';
+import { ConfuseRayEffect } from './effects/confuse-ray-effect';
+import { SweetKissEffect } from './effects/sweet-kiss-effect';
+import { TeeterDanceEffect } from './effects/teeter-dance-effect';
+import { SwaggerEffect } from './effects/swagger-effect';
+import { FlatterEffect } from './effects/flatter-effect';
 
 /**
  * 技のレジストリ
@@ -205,6 +211,13 @@ export class MoveRegistry {
       this.registry.set('どくのこな', new PoisonPowderEffect());
       this.registry.set('どくガス', new PoisonGasEffect());
       this.registry.set('どくのいと', new ToxicThreadEffect());
+      // 変化カテゴリこんらん付与系（Issue #105）
+      this.registry.set('ちょうおんぱ', new SupersonicEffect());
+      this.registry.set('あやしいひかり', new ConfuseRayEffect());
+      this.registry.set('てんしのキッス', new SweetKissEffect());
+      this.registry.set('フラフラダンス', new TeeterDanceEffect());
+      this.registry.set('いばる', new SwaggerEffect());
+      this.registry.set('おだてる', new FlatterEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #105「変化カテゴリの未実装技の特殊効果: こんらん付与 (6件)」**すべて実装**。

### 実装した技
| 技 | 効果 |
|---|---|
| ちょうおんぱ | こんらん必中 |
| あやしいひかり | こんらん必中 |
| てんしのキッス | こんらん必中 |
| フラフラダンス | こんらん必中（本来は場の全員対象だが、現状単体対象として実装） |
| いばる | 相手の攻撃 +2 + こんらん |
| おだてる | 相手の特攻 +1 + こんらん |

### 設計メモ
- 単純な「こんらん必中」4件は `BaseStatusConditionEffect` 拡張で `StatusCondition.Confusion` を `chance=1.0` で付与
- いばる / おだてる は「相手の能力を上げる + こんらん付与」という共通パターンを `BaseConfuseWithStatBoostEffect` として抽出
  - 能力上昇とこんらん付与は独立試行（片方失敗してももう片方は実行）
  - 既存の `BaseOpponentStatChangeMoveEffect` と `BaseStatusConditionEffect` の機能を組み合わせた構造

### 注意点
- 現状の engine では `statusCondition` が単一スロットのため、対象が既に状態異常（やけど・まひ等）を持つ場合はこんらんが付与されない。本家ではこんらんは独立した volatile status だが、データモデル上の制約として受容
- フラフラダンスは本来「場の全員（味方含む）に対象拡張」だが、現状の `onUse(defender)` API では単体しか扱えないため、単体対象として実装。範囲攻撃 API は engine 拡張が必要

## Test plan
- [x] `base-confuse-with-stat-boost-effect.spec.ts` 追加: 5ケース（Swagger相当の+2/上限処理/既存状態異常時 + Flatter相当の特攻+1 + リポジトリ無し）
- [x] `npm test`: 120 suites / 696 tests Pass（既存の flaky テスト `エアスラッシュは30%の確率でひるみを付与する` が1回失敗、再実行で全 Pass — 当 PR の変更とは無関係）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #105