### PR TITLE
feat: 変化カテゴリひるみ付与の技効果を追加 (Issue #121)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/no-retreat-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/no-retreat-effect.spec.ts
@@ -1,0 +1,107 @@
+import { NoRetreatEffect } from './no-retreat-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+import { Move, MoveCategory } from '@/modules/pokemon/domain/entities/move.entity';
+import { Type } from '@/modules/pokemon/domain/entities/type.entity';
+
+describe('NoRetreatEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  const createMove = (): Move => {
+    return {
+      id: 1,
+      name: 'はいすいのじん',
+      nameEn: 'no-retreat',
+      type: { id: 1, name: 'はがね' } as Type,
+      category: 'Physical' as MoveCategory,
+      power: 60,
+      accuracy: 100,
+      pp: 5,
+      priority: 0,
+      description: null,
+    } as Move;
+  };
+
+  it('beforeDamage で multiHitCount を 2 に設定する', async () => {
+    const effect = new NoRetreatEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+    const move = createMove();
+
+    await effect.beforeDamage(attacker, defender, move, ctx);
+
+    expect(ctx.multiHitCount).toBe(2);
+  });
+
+  it('onHit で相手にひるみを付与する', async () => {
+    const effect = new NoRetreatEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe('flinched!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      statusCondition: StatusCondition.Flinch,
+    });
+  });
+
+  it('既に状態異常がある場合はひるみを付与しない', async () => {
+    const effect = new NoRetreatEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2, statusCondition: StatusCondition.Burn });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は null', async () => {
+    const effect = new NoRetreatEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/no-retreat-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/no-retreat-effect.ts
@@ -1,0 +1,38 @@
+import { BaseMultiHitEffect } from './base-multi-hit-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「はいすいのじん」の特殊効果実装
+ *
+ * 効果: 1ターンに2回攻撃し、必ず相手をひるませる
+ *       (Hits twice in one turn, with a 100% chance to make the target flinch)
+ *
+ * - 攻撃回数の決定は BaseMultiHitEffect が担う
+ * - ひるみ付与は命中後（onHit）に常時実行する
+ */
+export class NoRetreatEffect extends BaseMultiHitEffect {
+  protected readonly minHits = 2;
+  protected readonly maxHits = 2;
+
+  async onHit(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    if (defender.statusCondition && defender.statusCondition !== StatusCondition.None) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      statusCondition: StatusCondition.Flinch,
+    });
+
+    return 'flinched!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -88,6 +88,7 @@ import { SweetKissEffect } from './effects/sweet-kiss-effect';
 import { TeeterDanceEffect } from './effects/teeter-dance-effect';
 import { SwaggerEffect } from './effects/swagger-effect';
 import { FlatterEffect } from './effects/flatter-effect';
+import { NoRetreatEffect } from './effects/no-retreat-effect';
 
 /**
  * 技のレジストリ
@@ -218,6 +219,8 @@ export class MoveRegistry {
       this.registry.set('フラフラダンス', new TeeterDanceEffect());
       this.registry.set('いばる', new SwaggerEffect());
       this.registry.set('おだてる', new FlatterEffect());
+      // 変化カテゴリひるみ付与系（Issue #121）
+      this.registry.set('はいすいのじん', new NoRetreatEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #121「変化カテゴリの未実装技の特殊効果: ひるみ付与 (1件)」を実装。

| 技 | 効果 |
|---|---|
| はいすいのじん | 1ターンに2回攻撃、命中時に必ずひるみ付与 |

### 設計メモ
- `BaseMultiHitEffect` を継承（既存 `PinMissileEffect` と同パターン）し、`minHits=maxHits=2` で固定2回ヒット
- `onHit` を override してひるみを必中で付与（既存 `AirSlashEffect` と同じ「状態異常付与」ロジックを `chance=1.0` 相当で実装）
- 既に他の状態異常を持つ場合はスキップ（engine の単一スロット制約に追従）

### 注
Issue 本文の技説明（"Hits twice in one turn, with a 100% chance to make the target flinch"）は本家の "No Retreat"（全能力 +1 + 交代不可）と一致しません。Issue の記述（2回攻撃 + ひるみ）に従って実装しています。

## Test plan
- [x] `no-retreat-effect.spec.ts` 追加: 4ケース（multiHit設定 / ひるみ付与 / 既存状態異常時スキップ / リポジトリ無し）
- [x] `npm test`: 120 suites / 695 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #121