### PR TITLE
feat: 特殊カテゴリ反動ダメージの技効果を追加 (Issue #101)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/light-of-ruin-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/light-of-ruin-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「はめつのひかり」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/2を反動として受ける (User receives 1/2 the damage inflicted in recoil)
+ */
+export class LightOfRuinEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 2;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -89,6 +89,7 @@ import { TeeterDanceEffect } from './effects/teeter-dance-effect';
 import { SwaggerEffect } from './effects/swagger-effect';
 import { FlatterEffect } from './effects/flatter-effect';
 import { NoRetreatEffect } from './effects/no-retreat-effect';
+import { LightOfRuinEffect } from './effects/light-of-ruin-effect';
 
 /**
  * 技のレジストリ
@@ -221,6 +222,8 @@ export class MoveRegistry {
       this.registry.set('おだてる', new FlatterEffect());
       // 変化カテゴリひるみ付与系（Issue #121）
       this.registry.set('はいすいのじん', new NoRetreatEffect());
+      // 特殊カテゴリ反動ダメージ系（Issue #101）
+      this.registry.set('はめつのひかり', new LightOfRuinEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #101「特殊カテゴリの未実装技の特殊効果: 反動ダメージ (1件)」を実装。

| 技 | 効果 |
|---|---|
| はめつのひかり | 与えたダメージの1/2を反動として受ける |

`BaseRecoilEffect` を継承（既存 `DoubleEdgeEffect`（1/3 反動）と同パターン）で `recoilRatio = 1/2`。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass（`BaseRecoilEffect` の既存テストで反動ロジックは網羅）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。`BaseRecoilEffect` の `base-recoil-effect.spec.ts` で反動計算の汎用挙動が網羅されており、`recoilRatio` 設定値の検証のみで十分。

Closes #101