### PR TITLE
feat: 変化カテゴリ天候の技効果を追加 (Issue #115)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -138,6 +138,7 @@ export class MoveRegistry {
       this.registry.set('つるぎのまい', new SwordsDanceEffect());
       // 天候変更系の変化技
       this.registry.set('あめをよぶ', new RainDanceEffect());
+      this.registry.set('あまごい', new RainDanceEffect()); // Issue #115: あめをよぶの別表記
       this.registry.set('にほんばれ', new SunnyDayEffect());
       this.registry.set('すなあらし', new SandstormMoveEffect());
       this.registry.set('あられ', new HailMoveEffect());


### PR DESCRIPTION
## Summary
Issue #115「変化カテゴリの未実装技の特殊効果: 天候関連 (1件)」を実装。

| 技 | 効果 |
|---|---|
| あまごい | 天候を5ターン雨にする（既存 `RainDanceEffect` のエイリアス登録） |

### 設計メモ
- `あまごい` は本家の Gen5+ 正式表記、既存登録の `あめをよぶ` は Gen1-4 表記。どちらも英名 "Rain Dance" を指す
- DB に `あまごい` が含まれている可能性を考慮し、同一の `RainDanceEffect` インスタンス（ロジックは完全に同じ）を別名でも引けるよう登録
- もし DB に両方の表記が存在する場合は両方カバー、`あまごい` のみ存在する場合もカバーされる

### 別案
DB を一方の表記に統一する案もあるが、データ移行・スクレイパー側の修正コストがかかるためコード側のエイリアスで対応するのが軽量。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Closes #115