### PR TITLE
feat: 変化カテゴリ威力変化の技効果を追加 (Issue #122)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/charge-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/charge-effect.ts
@@ -1,0 +1,16 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「じゅうでん」の特殊効果実装
+ *
+ * 効果: 自分の特防ランクを1段階上げる
+ *
+ * 注: 「次ターンの電気技の威力が2倍になる」効果は、ターンをまたぐ永続フラグと
+ *     技の威力を動的に修正する仕組み（power-modifier）の両方が必要なため、
+ *     現状の engine には対応するフックがなく、別処理として保留する。
+ */
+export class ChargeEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialDefense';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -90,6 +90,7 @@ import { SwaggerEffect } from './effects/swagger-effect';
 import { FlatterEffect } from './effects/flatter-effect';
 import { NoRetreatEffect } from './effects/no-retreat-effect';
 import { LightOfRuinEffect } from './effects/light-of-ruin-effect';
+import { ChargeEffect } from './effects/charge-effect';
 
 /**
  * 技のレジストリ
@@ -225,6 +226,8 @@ export class MoveRegistry {
       this.registry.set('はいすいのじん', new NoRetreatEffect());
       // 特殊カテゴリ反動ダメージ系（Issue #101）
       this.registry.set('はめつのひかり', new LightOfRuinEffect());
+      // 変化カテゴリ威力変化系（Issue #122）
+      this.registry.set('じゅうでん', new ChargeEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #122「変化カテゴリの未実装技の特殊効果: 威力変化 (1件)」のうち実装可能な部分を実装。

| 技 | 実装した効果 |
|---|---|
| じゅうでん | 自分の特防ランクを1段階上げる |

### 設計メモ
- `BaseSelfStatChangeMoveEffect` 継承（既存 `SwordsDanceEffect` / `HardenEffect` と同パターン）

### 保留した部分
- **「次ターンの電気技の威力が2倍」**: 以下の2つが engine 未整備のため見送り
  - ターンをまたぐ永続フラグ（"charged" 状態を `BattlePokemonStatus` に保持）
  - 技タイプに応じた power-modifier（`からげんき` / `ベノムショック` 等と共通の課題）

→ engine 拡張時にまとめて対応すべき（power-modifier API + 永続フラグの追加）

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。`BaseSelfStatChangeMoveEffect` の既存テストで網羅。

Refs #122