### PR TITLE
feat: 変化カテゴリ「効果なし」の技効果を追加 (Issue #113)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/no-op-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/no-op-effect.ts
@@ -1,0 +1,23 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「何も起こらない」変化技の特殊効果実装
+ *
+ * 使用例: はねる、おいわい、てをつなぐ
+ * 効果: 何もしない（メッセージのみ）
+ *
+ * 仕組み: `MoveRegistry` のカバレッジチェックを満たすために、変化技として
+ *         登録される必要がある「何もしない」技用の共通実装。
+ *         単一の stateless インスタンスを複数の技名にエイリアス登録できる。
+ */
+export class NoOpEffect implements IMoveEffect {
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    _battleContext: BattleContext,
+  ): Promise<string | null> {
+    return 'But nothing happened!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -91,6 +91,7 @@ import { FlatterEffect } from './effects/flatter-effect';
 import { NoRetreatEffect } from './effects/no-retreat-effect';
 import { LightOfRuinEffect } from './effects/light-of-ruin-effect';
 import { ChargeEffect } from './effects/charge-effect';
+import { NoOpEffect } from './effects/no-op-effect';
 
 /**
  * 技のレジストリ
@@ -228,6 +229,12 @@ export class MoveRegistry {
       this.registry.set('はめつのひかり', new LightOfRuinEffect());
       // 変化カテゴリ威力変化系（Issue #122）
       this.registry.set('じゅうでん', new ChargeEffect());
+      // 変化カテゴリ「効果なし」系（Issue #113）
+      // 何もしない変化技は単一の NoOpEffect インスタンスを複数の技名で共有
+      const noOpEffect = new NoOpEffect();
+      this.registry.set('はねる', noOpEffect);
+      this.registry.set('おいわい', noOpEffect);
+      this.registry.set('てをつなぐ', noOpEffect);
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #113「変化カテゴリの未実装技の特殊効果: 効果なし (3件)」を実装。

| 技 | 効果 |
|---|---|
| はねる | 何もしない |
| おいわい | 何もしない |
| てをつなぐ | 何もしない |

### 設計メモ
- 単一の `NoOpEffect` インスタンスを3技で共有エイリアス登録（stateless なクラスなのでメモリ効率と保守性の両面でメリット）
- `onUse` は `"But nothing happened!"` を返し、move-executor 側で `Used <技名> But nothing happened!` と表示される

### なぜ登録するか
`MoveRegistry` のカバレッジチェックは Status 技を「特殊効果を持つ可能性あり」と判定する。実態として「何もしない」技も明示的に登録することで網羅性を担保する。

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: ロジックが極めて単純（`return メッセージ` のみ）のため個別 spec は割愛。

Closes #113