### PR TITLE
feat: 変化カテゴリ防御技の技効果を追加 (Issue #120)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/psychic-terrain-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/psychic-terrain-effect.ts
@@ -1,0 +1,37 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { Field } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * 「サイコフィールド」の特殊効果実装
+ *
+ * 効果: 5ターン間、地面にいるポケモンを先制技から守り、エスパー技の威力を1.5倍にする
+ *
+ * 注: 「地面にいるポケモンへの先制技ブロック」「エスパー技威力 1.5倍」のダメージ計算側修正は
+ *     現状の damage calculator / accuracy checker に対応するフックがなく、別処理（engine 拡張）で扱う想定。
+ *     ここではフィールド変更のみを担う。
+ */
+export class PsychicTerrainEffect implements IMoveEffect {
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const battle = battleContext.battle;
+
+    if (battle.field === Field.PsychicTerrain) {
+      return null;
+    }
+
+    await battleContext.battleRepository.update(battle.id, {
+      field: Field.PsychicTerrain,
+    });
+
+    return 'Psychic Terrain was set up!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -92,6 +92,7 @@ import { NoRetreatEffect } from './effects/no-retreat-effect';
 import { LightOfRuinEffect } from './effects/light-of-ruin-effect';
 import { ChargeEffect } from './effects/charge-effect';
 import { NoOpEffect } from './effects/no-op-effect';
+import { PsychicTerrainEffect } from './effects/psychic-terrain-effect';
 
 /**
  * 技のレジストリ
@@ -235,6 +236,8 @@ export class MoveRegistry {
       this.registry.set('はねる', noOpEffect);
       this.registry.set('おいわい', noOpEffect);
       this.registry.set('てをつなぐ', noOpEffect);
+      // 変化カテゴリ防御技系（Issue #120）
+      this.registry.set('サイコフィールド', new PsychicTerrainEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #120「変化カテゴリの未実装技の特殊効果: 防御技 (4件)」のうち **1件のみ実装**。残り3件は engine 未整備で保留。

### 実装した技
| 技 | 効果 |
|---|---|
| サイコフィールド | フィールドを Psychic Terrain に変更（5ターン） |

- 既存 `MistyTerrainEffect` と同じパターンで `Field.PsychicTerrain` に変更
- 「地面ポケへの先制技ブロック」「エスパー技威力1.5倍」はダメージ計算側で別処理（damage calculator / accuracy checker に Field 依存フックを追加する必要あり）

### 保留した技（3件）
- **トリックガード (Crafty Shield)**: 味方全体を変化技から守る。protect mechanism + party-wide buff が engine 未整備
- **ニードルガード (Spiky Shield)**: 攻撃技から守る + 接触してきた相手に 1/8 HP ダメージ。protect + contact-reaction が未整備（`トーチカ` と同様）
- **たたみがえし (Mat Block)**: 味方全体を攻撃技から守る + 場に出た最初のターンのみ。protect + party-wide + first-turn-only と機構が複雑

→ いずれも protect 系の共通 API（1ターンガード）の engine 拡張が必要

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #120