### PR TITLE
feat: 物理カテゴリどく付与の技効果を追加 (Issue #128)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/cross-poison-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/cross-poison-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「クロスポイズン」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にどくを付与 (Has a 10% chance to poison the target)
+ * 注: 急所率上昇は別処理（ダメージ計算側）で扱う
+ */
+export class CrossPoisonEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/gunk-shot-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/gunk-shot-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ダストシュート」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にどくを付与 (Has a 30% chance to poison the target)
+ */
+export class GunkShotEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/poison-fang-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-fang-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくどくのキバ」の特殊効果実装
+ *
+ * 効果: 50%の確率で相手にもうどくを付与 (Has a 50% chance to badly poison the target)
+ */
+export class PoisonFangEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.BadPoison;
+  protected readonly chance = 0.5;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was badly poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/poison-jab-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-jab-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくづき」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にどくを付与 (Has a 30% chance to poison the target)
+ */
+export class PoisonJabEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/poison-sting-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-sting-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「どくばり」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にどくを付与 (Has a 30% chance to poison the target)
+ */
+export class PoisonStingEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/poison-tail-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/poison-tail-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ポイズンテール」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にどくを付与 (Has a 10% chance to poison the target)
+ * 注: 急所率上昇は別処理（ダメージ計算側）で扱う
+ */
+export class PoisonTailEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Poison;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['どく', 'はがね'];
+  protected readonly message = 'was poisoned!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -93,6 +93,12 @@ import { LightOfRuinEffect } from './effects/light-of-ruin-effect';
 import { ChargeEffect } from './effects/charge-effect';
 import { NoOpEffect } from './effects/no-op-effect';
 import { PsychicTerrainEffect } from './effects/psychic-terrain-effect';
+import { PoisonStingEffect } from './effects/poison-sting-effect';
+import { PoisonFangEffect } from './effects/poison-fang-effect';
+import { PoisonTailEffect } from './effects/poison-tail-effect';
+import { PoisonJabEffect } from './effects/poison-jab-effect';
+import { CrossPoisonEffect } from './effects/cross-poison-effect';
+import { GunkShotEffect } from './effects/gunk-shot-effect';
 
 /**
  * 技のレジストリ
@@ -238,6 +244,13 @@ export class MoveRegistry {
       this.registry.set('てをつなぐ', noOpEffect);
       // 変化カテゴリ防御技系（Issue #120）
       this.registry.set('サイコフィールド', new PsychicTerrainEffect());
+      // 物理カテゴリどく付与系（Issue #128）
+      this.registry.set('どくばり', new PoisonStingEffect());
+      this.registry.set('どくどくのキバ', new PoisonFangEffect());
+      this.registry.set('ポイズンテール', new PoisonTailEffect());
+      this.registry.set('どくづき', new PoisonJabEffect());
+      this.registry.set('クロスポイズン', new CrossPoisonEffect());
+      this.registry.set('ダストシュート', new GunkShotEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #128「物理カテゴリの未実装技の特殊効果: どく付与 (6件)」**全件実装**。

| 技 | 効果 |
|---|---|
| どくばり | 30% どく |
| どくどくのキバ | 50% もうどく |
| ポイズンテール | 10% どく（急所率上昇は別処理） |
| どくづき | 30% どく |
| クロスポイズン | 10% どく（急所率上昇は別処理） |
| ダストシュート | 30% どく |

いずれも `BaseStatusConditionEffect` 継承（`ToxicEffect` / `PoisonStingEffect` 等と同パターン）。どく・はがねタイプには免疫。

### 注
- ポイズンテール / クロスポイズン の「急所率上昇」は `ブレイズキック`（#123）と同様、ダメージ計算側で別処理

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛（`BaseStatusConditionEffect` の既存テストで網羅）。

Closes #128