### PR TITLE
feat: 物理カテゴリ反動ダメージの技効果を追加 (Issue #127)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/brave-bird-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/brave-bird-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「ブレイブバード」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/3を反動として受ける
+ */
+export class BraveBirdEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 3;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/head-charge-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/head-charge-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「アフロブレイク」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/4を反動として受ける
+ */
+export class HeadChargeEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 4;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/head-smash-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/head-smash-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「もろはのずつき」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/2を反動として受ける
+ */
+export class HeadSmashEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 2;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/submission-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/submission-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「じごくぐるま」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/4を反動として受ける
+ */
+export class SubmissionEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 4;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/wild-charge-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/wild-charge-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「ワイルドボルト」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/4を反動として受ける
+ */
+export class WildChargeEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 4;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/wood-hammer-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/wood-hammer-effect.ts
@@ -1,0 +1,11 @@
+import { BaseRecoilEffect } from './base/base-recoil-effect';
+
+/**
+ * 「ウッドハンマー」の特殊効果実装
+ *
+ * 効果: 与えたダメージの1/3を反動として受ける
+ */
+export class WoodHammerEffect extends BaseRecoilEffect {
+  protected readonly recoilRatio = 1 / 3;
+  protected readonly message = '反動で{damage}ダメージを受けた';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -99,6 +99,12 @@ import { PoisonTailEffect } from './effects/poison-tail-effect';
 import { PoisonJabEffect } from './effects/poison-jab-effect';
 import { CrossPoisonEffect } from './effects/cross-poison-effect';
 import { GunkShotEffect } from './effects/gunk-shot-effect';
+import { SubmissionEffect } from './effects/submission-effect';
+import { BraveBirdEffect } from './effects/brave-bird-effect';
+import { HeadSmashEffect } from './effects/head-smash-effect';
+import { WoodHammerEffect } from './effects/wood-hammer-effect';
+import { WildChargeEffect } from './effects/wild-charge-effect';
+import { HeadChargeEffect } from './effects/head-charge-effect';
 
 /**
  * 技のレジストリ
@@ -251,6 +257,13 @@ export class MoveRegistry {
       this.registry.set('どくづき', new PoisonJabEffect());
       this.registry.set('クロスポイズン', new CrossPoisonEffect());
       this.registry.set('ダストシュート', new GunkShotEffect());
+      // 物理カテゴリ反動ダメージ系（Issue #127）
+      this.registry.set('じごくぐるま', new SubmissionEffect());
+      this.registry.set('ブレイブバード', new BraveBirdEffect());
+      this.registry.set('もろはのずつき', new HeadSmashEffect());
+      this.registry.set('ウッドハンマー', new WoodHammerEffect());
+      this.registry.set('ワイルドボルト', new WildChargeEffect());
+      this.registry.set('アフロブレイク', new HeadChargeEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #127「物理カテゴリの未実装技の特殊効果: 反動ダメージ (9件)」のうち **6件を実装**。残る3件は別パターンが未整備のため保留。

### 実装した技
| 技 | 反動率 |
|---|---|
| じごくぐるま | 1/4 |
| ブレイブバード | 1/3 |
| もろはのずつき | 1/2 |
| ウッドハンマー | 1/3 |
| ワイルドボルト | 1/4 |
| アフロブレイク | 1/4 |

いずれも `BaseRecoilEffect` 継承（既存 `DoubleEdgeEffect` / `LightOfRuinEffect`（#101）と同パターン）。

### 保留した技（3件）
- **とびげり (Jump Kick)** / **とびひざげり (High Jump Kick)**: 「外したときに**与えていたであろう**ダメージの1/2を受ける」。`onMiss` で「ダメージ予測」をする仕組みが未整備（現状 `BaseRecoilEffect` は `afterDamage` のみ実装、外した場合の予測ダメージ計算フックが無い）
- **わるあがき (Struggle)**: 「**最大HPの**1/4を反動として受ける」。既存 `BaseRecoilEffect` は「与えたダメージ × 反動率」の計算式のみ対応。max-HP-based の反動には別 base が必要

→ いずれも新たな base class（`BaseMissRecoilEffect`、`BaseMaxHpRecoilEffect` 等）を engine 側で追加する必要あり

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass（`BaseRecoilEffect` の既存テストで反動ロジックは網羅）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。`BaseRecoilEffect` の `base-recoil-effect.spec.ts` で反動計算の汎用挙動が網羅されており、`recoilRatio` 設定値の検証のみで十分。

Refs #127