### PR TITLE
feat: 物理カテゴリまひ付与の技効果を追加 (Issue #125)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/body-slam-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/body-slam-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「のしかかり」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class BodySlamEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/bolt-strike-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/bolt-strike-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「らいげき」の特殊効果実装
+ *
+ * 効果: 20%の確率で相手にまひを付与 (Has a 20% chance to paralyze the target)
+ */
+export class BoltStrikeEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/force-palm-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/force-palm-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「はっけい」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class ForcePalmEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/freeze-shock-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/freeze-shock-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「フリーズボルト」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ * 注: 1ターンチャージは別処理（バトルフロー）で扱う想定（既存 IceBurnEffect と同方針）
+ */
+export class FreezeShockEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/lick-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/lick-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「したでなめる」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class LickEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/nuzzle-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/nuzzle-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ほっぺすりすり」の特殊効果実装
+ *
+ * 効果: 必ず相手にまひを付与 (Has a 100% chance to paralyze the target)
+ */
+export class NuzzleEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/smelling-salts-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/smelling-salts-effect.ts
@@ -1,0 +1,33 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「きつけ」の特殊効果実装
+ *
+ * 効果: 相手がまひ状態のときに命中させるとまひを解除する
+ * 注: 「相手がまひ状態のときに威力2倍」の効果は、技の威力を動的に修正する
+ *     power-modifier API が未整備のため別処理（ダメージ計算側）で扱う
+ */
+export class SmellingSaltsEffect implements IMoveEffect {
+  async onHit(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    if (defender.statusCondition !== StatusCondition.Paralysis) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      statusCondition: StatusCondition.None,
+    });
+
+    return "target's paralysis was cured!";
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/spark-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/spark-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「スパーク」の特殊効果実装
+ *
+ * 効果: 30%の確率で相手にまひを付与 (Has a 30% chance to paralyze the target)
+ */
+export class SparkEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/thunder-punch-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/thunder-punch-effect.ts
@@ -1,0 +1,14 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「かみなりパンチ」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にまひを付与 (Has a 10% chance to paralyze the target)
+ */
+export class ThunderPunchEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/volt-tackle-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/volt-tackle-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ボルテッカー」の特殊効果実装
+ *
+ * 効果: 10%の確率で相手にまひを付与 (Has a 10% chance to paralyze the target)
+ * 注: 反動ダメージ（与えたダメージの1/3）は別 Issue（#127系）で扱う
+ */
+export class VoltTackleEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Paralysis;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes = ['でんき'];
+  protected readonly message = 'was paralyzed!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -105,6 +105,16 @@ import { HeadSmashEffect } from './effects/head-smash-effect';
 import { WoodHammerEffect } from './effects/wood-hammer-effect';
 import { WildChargeEffect } from './effects/wild-charge-effect';
 import { HeadChargeEffect } from './effects/head-charge-effect';
+import { ThunderPunchEffect } from './effects/thunder-punch-effect';
+import { BodySlamEffect } from './effects/body-slam-effect';
+import { LickEffect } from './effects/lick-effect';
+import { SparkEffect } from './effects/spark-effect';
+import { SmellingSaltsEffect } from './effects/smelling-salts-effect';
+import { VoltTackleEffect } from './effects/volt-tackle-effect';
+import { ForcePalmEffect } from './effects/force-palm-effect';
+import { FreezeShockEffect } from './effects/freeze-shock-effect';
+import { NuzzleEffect } from './effects/nuzzle-effect';
+import { BoltStrikeEffect } from './effects/bolt-strike-effect';
 
 /**
  * 技のレジストリ
@@ -264,6 +274,17 @@ export class MoveRegistry {
       this.registry.set('ウッドハンマー', new WoodHammerEffect());
       this.registry.set('ワイルドボルト', new WildChargeEffect());
       this.registry.set('アフロブレイク', new HeadChargeEffect());
+      // 物理カテゴリまひ付与系（Issue #125）
+      this.registry.set('かみなりパンチ', new ThunderPunchEffect());
+      this.registry.set('のしかかり', new BodySlamEffect());
+      this.registry.set('したでなめる', new LickEffect());
+      this.registry.set('スパーク', new SparkEffect());
+      this.registry.set('きつけ', new SmellingSaltsEffect());
+      this.registry.set('ボルテッカー', new VoltTackleEffect());
+      this.registry.set('はっけい', new ForcePalmEffect());
+      this.registry.set('フリーズボルト', new FreezeShockEffect());
+      this.registry.set('ほっぺすりすり', new NuzzleEffect());
+      this.registry.set('らいげき', new BoltStrikeEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #125「物理カテゴリの未実装技の特殊効果: まひ付与 (10件)」**全件実装**。

### 実装した技
| 技 | 効果 |
|---|---|
| かみなりパンチ | 10% まひ |
| のしかかり | 30% まひ |
| したでなめる | 30% まひ |
| スパーク | 30% まひ |
| きつけ | 相手のまひを治癒（威力2倍は別処理） |
| ボルテッカー | 10% まひ（反動1/3は engine 未整備） |
| はっけい | 30% まひ |
| フリーズボルト | 30% まひ（チャージは別処理、`IceBurnEffect` と同方針） |
| ほっぺすりすり | 100% まひ |
| らいげき | 20% まひ |

### 設計メモ
- 単純な確率まひ付与（8件）は `BaseStatusConditionEffect` 継承
- きつけ は `SparklingAriaEffect`（やけど治癒）と同じ「相手の特定状態異常を解除する」`onHit` パターンで実装
- でんきタイプは Gen6+ 仕様でまひ免疫（すべての技で `immuneTypes = ['でんき']`）
- きつけの「威力2倍」、ボルテッカーの反動、フリーズボルトのチャージは engine 未整備のため別処理

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。きつけは `SparklingAriaEffect` と同じ単純パターンのため明示的なテストは不要と判断。

Closes #125