### PR TITLE
feat: 特殊カテゴリ能力変化の技効果を追加 (Issue #99)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/ancient-power-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/ancient-power-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfAllStatsBoostEffect } from './base/base-self-all-stats-boost-effect';
+
+/**
+ * 「げんしのちから」の特殊効果実装
+ *
+ * 効果: 10%の確率で自分の全能力ランクを1段階上昇
+ */
+export class AncientPowerEffect extends BaseSelfAllStatsBoostEffect {
+  protected readonly chance = 0.1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-self-all-stats-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-self-all-stats-boost-effect.spec.ts
@@ -1,0 +1,133 @@
+import { BaseSelfAllStatsBoostEffect } from './base-self-all-stats-boost-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestAllStatsBoost10 extends BaseSelfAllStatsBoostEffect {
+  protected readonly chance = 0.1;
+}
+
+class TestAllStatsBoost100 extends BaseSelfAllStatsBoostEffect {
+  protected readonly chance = 1.0;
+}
+
+describe('BaseSelfAllStatsBoostEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('確率が当たれば主要5能力 +1', async () => {
+    const effect = new TestAllStatsBoost100();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe("user's stats rose!");
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      attackRank: 1,
+      defenseRank: 1,
+      specialAttackRank: 1,
+      specialDefenseRank: 1,
+      speedRank: 1,
+    });
+  });
+
+  it('確率が外れたら何もしない', async () => {
+    const effect = new TestAllStatsBoost10();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
+
+  it('既に全て上限のときは何もしない', async () => {
+    const effect = new TestAllStatsBoost100();
+    const attacker = createBattlePokemonStatus({
+      attackRank: 6,
+      defenseRank: 6,
+      specialAttackRank: 6,
+      specialDefenseRank: 6,
+      speedRank: 6,
+    });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('既存ランクから +1 し上限は6でクランプ', async () => {
+    const effect = new TestAllStatsBoost100();
+    const attacker = createBattlePokemonStatus({
+      attackRank: 6,
+      defenseRank: 3,
+      specialAttackRank: 0,
+      specialDefenseRank: -1,
+      speedRank: 5,
+    });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBe("user's stats rose!");
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      attackRank: 6, // 既に6なのでそのまま
+      defenseRank: 4,
+      specialAttackRank: 1,
+      specialDefenseRank: 0,
+      speedRank: 6,
+    });
+  });
+
+  it('battleRepository が無い場合は null', async () => {
+    const effect = new TestAllStatsBoost100();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onHit(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-self-all-stats-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-self-all-stats-boost-effect.ts
@@ -1,0 +1,61 @@
+import { IMoveEffect } from '../../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../../abilities/battle-context.interface';
+
+/**
+ * 「攻撃技 + 確率で自分の全能力ランクを1段階上昇」変化技の基底クラス
+ *
+ * 例: げんしのちから・ぎんいろのかぜ・あやしいかぜ
+ *
+ * - 上昇対象: 攻撃・防御・特攻・特防・素早さ（命中・回避は対象外、本家挙動）
+ * - 確率は派生クラスで指定
+ */
+export abstract class BaseSelfAllStatsBoostEffect implements IMoveEffect {
+  /**
+   * ステータス上昇確率（0.0-1.0）
+   */
+  protected abstract readonly chance: number;
+
+  async onHit(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    if (this.chance < 1.0 && Math.random() >= this.chance) {
+      return null;
+    }
+
+    const clampUp = (current: number): number => Math.max(-6, Math.min(6, current + 1));
+
+    const newAttackRank = clampUp(attacker.attackRank);
+    const newDefenseRank = clampUp(attacker.defenseRank);
+    const newSpecialAttackRank = clampUp(attacker.specialAttackRank);
+    const newSpecialDefenseRank = clampUp(attacker.specialDefenseRank);
+    const newSpeedRank = clampUp(attacker.speedRank);
+
+    // 全てが既に上限の場合は何も起こらない
+    if (
+      newAttackRank === attacker.attackRank &&
+      newDefenseRank === attacker.defenseRank &&
+      newSpecialAttackRank === attacker.specialAttackRank &&
+      newSpecialDefenseRank === attacker.specialDefenseRank &&
+      newSpeedRank === attacker.speedRank
+    ) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      attackRank: newAttackRank,
+      defenseRank: newDefenseRank,
+      specialAttackRank: newSpecialAttackRank,
+      specialDefenseRank: newSpecialDefenseRank,
+      speedRank: newSpeedRank,
+    });
+
+    return "user's stats rose!";
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/clear-smog-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/clear-smog-effect.ts
@@ -1,0 +1,45 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「クリアスモッグ」の特殊効果実装
+ *
+ * 効果: 相手の能力ランクをすべて 0 にリセットする
+ */
+export class ClearSmogEffect implements IMoveEffect {
+  async onHit(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    // 既にすべて 0 の場合は何もしない
+    if (
+      defender.attackRank === 0 &&
+      defender.defenseRank === 0 &&
+      defender.specialAttackRank === 0 &&
+      defender.specialDefenseRank === 0 &&
+      defender.speedRank === 0 &&
+      defender.accuracyRank === 0 &&
+      defender.evasionRank === 0
+    ) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      attackRank: 0,
+      defenseRank: 0,
+      specialAttackRank: 0,
+      specialDefenseRank: 0,
+      speedRank: 0,
+      accuracyRank: 0,
+      evasionRank: 0,
+    });
+
+    return "target's stat changes were eliminated!";
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/ominous-wind-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/ominous-wind-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfAllStatsBoostEffect } from './base/base-self-all-stats-boost-effect';
+
+/**
+ * 「あやしいかぜ」の特殊効果実装
+ *
+ * 効果: 10%の確率で自分の全能力ランクを1段階上昇
+ */
+export class OminousWindEffect extends BaseSelfAllStatsBoostEffect {
+  protected readonly chance = 0.1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/silver-wind-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/silver-wind-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfAllStatsBoostEffect } from './base/base-self-all-stats-boost-effect';
+
+/**
+ * 「ぎんいろのかぜ」の特殊効果実装
+ *
+ * 効果: 10%の確率で自分の全能力ランクを1段階上昇
+ */
+export class SilverWindEffect extends BaseSelfAllStatsBoostEffect {
+  protected readonly chance = 0.1;
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -115,6 +115,10 @@ import { ForcePalmEffect } from './effects/force-palm-effect';
 import { FreezeShockEffect } from './effects/freeze-shock-effect';
 import { NuzzleEffect } from './effects/nuzzle-effect';
 import { BoltStrikeEffect } from './effects/bolt-strike-effect';
+import { AncientPowerEffect } from './effects/ancient-power-effect';
+import { SilverWindEffect } from './effects/silver-wind-effect';
+import { OminousWindEffect } from './effects/ominous-wind-effect';
+import { ClearSmogEffect } from './effects/clear-smog-effect';
 
 /**
  * 技のレジストリ
@@ -285,6 +289,11 @@ export class MoveRegistry {
       this.registry.set('フリーズボルト', new FreezeShockEffect());
       this.registry.set('ほっぺすりすり', new NuzzleEffect());
       this.registry.set('らいげき', new BoltStrikeEffect());
+      // 特殊カテゴリ能力変化系（Issue #99）
+      this.registry.set('げんしのちから', new AncientPowerEffect());
+      this.registry.set('ぎんいろのかぜ', new SilverWindEffect());
+      this.registry.set('あやしいかぜ', new OminousWindEffect());
+      this.registry.set('クリアスモッグ', new ClearSmogEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #99「特殊カテゴリの未実装技の特殊効果: 能力変化 (7件)」のうち **4件を実装**。残る3件は power-modifier 未整備のため保留。

### 実装した技
| 技 | 効果 |
|---|---|
| げんしのちから | 10% で自分の主要5能力 +1 |
| ぎんいろのかぜ | 10% で自分の主要5能力 +1 |
| あやしいかぜ | 10% で自分の主要5能力 +1 |
| クリアスモッグ | 相手の能力ランクを全リセット（攻/防/特攻/特防/速/命中/回避） |

### 設計メモ
- 「自分の主要5能力（攻撃・防御・特攻・特防・素早さ）を1段階上げる」効果は `BaseSelfAllStatsBoostEffect` として抽出。命中・回避は対象外（本家挙動）
- クリアスモッグは `HazeEffect`（場全体のリセット）の単体対象版として `onHit` で実装
- 上限値（+6）でクランプ、既に全て上限なら no-op

### 保留した技（3件）
- **たたりめ (Hex)**: 相手が状態異常なら威力2倍。power-modifier 未整備
- **てんこがすめつぼうのひかり (Light That Burns the Sky)**: 攻撃/特攻の高い方で計算。damage-calc 拡張が必要
- **アシストパワー (Stored Power)**: ステ上昇ぶんで威力スケール（最大31倍）。power-modifier 未整備

## Test plan
- [x] `base-self-all-stats-boost-effect.spec.ts` 追加: 5ケース（確率内/外、上限処理、ランク混在、リポジトリ無し）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #99