### PR TITLE
feat: 物理カテゴリひるみ付与の技効果を追加 (Issue #126)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/astonish-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/astonish-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「おどろかす」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class AstonishEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/bite-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/bite-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「かみつく」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class BiteEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/bone-club-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/bone-club-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ホネこんぼう」の特殊効果実装
+ *
+ * 効果: 0.1の確率で相手にひるみを付与
+
+ */
+export class BoneClubEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/dragon-rush-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/dragon-rush-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ドラゴンダイブ」の特殊効果実装
+ *
+ * 効果: 0.2の確率で相手にひるみを付与
+
+ */
+export class DragonRushEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/fake-out-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/fake-out-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ねこだまし」の特殊効果実装
+ *
+ * 効果: 1.0の確率で相手にひるみを付与
+ * 注: 「場に出た最初のターンのみ使用可能」は engine 未整備（turn counter / first-turn フラグが必要）
+ */
+export class FakeOutEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/headbutt-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/headbutt-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ずつき」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class HeadbuttEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/heart-stamp-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/heart-stamp-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ハートスタンプ」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class HeartStampEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/hyper-fang-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/hyper-fang-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ひっさつまえば」の特殊効果実装
+ *
+ * 効果: 0.1の確率で相手にひるみを付与
+
+ */
+export class HyperFangEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.1;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/icicle-crash-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/icicle-crash-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「つららおとし」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class IcicleCrashEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/iron-head-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/iron-head-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「アイアンヘッド」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class IronHeadEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/needle-arm-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/needle-arm-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ニードルアーム」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class NeedleArmEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/rock-slide-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/rock-slide-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「いわなだれ」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class RockSlideEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/rolling-kick-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/rolling-kick-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「まわしげり」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class RollingKickEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sky-attack-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sky-attack-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ゴッドバード」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+ * 注: 1ターンチャージは別処理（バトルフロー）で扱う
+ */
+export class SkyAttackEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/steamroller-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/steamroller-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ハードローラー」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class SteamrollerEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/stomp-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/stomp-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ふみつけ」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class StompEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/waterfall-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/waterfall-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「たきのぼり」の特殊効果実装
+ *
+ * 効果: 0.2の確率で相手にひるみを付与
+
+ */
+export class WaterfallEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/zen-headbutt-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/zen-headbutt-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「しねんのずつき」の特殊効果実装
+ *
+ * 効果: 0.2の確率で相手にひるみを付与
+
+ */
+export class ZenHeadbuttEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.2;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/zing-zap-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/zing-zap-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「びりびりちくちく」の特殊効果実装
+ *
+ * 効果: 0.3の確率で相手にひるみを付与
+
+ */
+export class ZingZapEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Flinch;
+  protected readonly chance = 0.3;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'flinched!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -119,6 +119,25 @@ import { AncientPowerEffect } from './effects/ancient-power-effect';
 import { SilverWindEffect } from './effects/silver-wind-effect';
 import { OminousWindEffect } from './effects/ominous-wind-effect';
 import { ClearSmogEffect } from './effects/clear-smog-effect';
+import { StompEffect } from './effects/stomp-effect';
+import { RollingKickEffect } from './effects/rolling-kick-effect';
+import { HeadbuttEffect } from './effects/headbutt-effect';
+import { BiteEffect } from './effects/bite-effect';
+import { BoneClubEffect } from './effects/bone-club-effect';
+import { WaterfallEffect } from './effects/waterfall-effect';
+import { SkyAttackEffect } from './effects/sky-attack-effect';
+import { RockSlideEffect } from './effects/rock-slide-effect';
+import { HyperFangEffect } from './effects/hyper-fang-effect';
+import { FakeOutEffect } from './effects/fake-out-effect';
+import { AstonishEffect } from './effects/astonish-effect';
+import { NeedleArmEffect } from './effects/needle-arm-effect';
+import { DragonRushEffect } from './effects/dragon-rush-effect';
+import { ZenHeadbuttEffect } from './effects/zen-headbutt-effect';
+import { IronHeadEffect } from './effects/iron-head-effect';
+import { HeartStampEffect } from './effects/heart-stamp-effect';
+import { SteamrollerEffect } from './effects/steamroller-effect';
+import { IcicleCrashEffect } from './effects/icicle-crash-effect';
+import { ZingZapEffect } from './effects/zing-zap-effect';
 
 /**
  * 技のレジストリ
@@ -294,6 +313,26 @@ export class MoveRegistry {
       this.registry.set('ぎんいろのかぜ', new SilverWindEffect());
       this.registry.set('あやしいかぜ', new OminousWindEffect());
       this.registry.set('クリアスモッグ', new ClearSmogEffect());
+      // 物理カテゴリひるみ付与系（Issue #126）
+      this.registry.set('ふみつけ', new StompEffect());
+      this.registry.set('まわしげり', new RollingKickEffect());
+      this.registry.set('ずつき', new HeadbuttEffect());
+      this.registry.set('かみつく', new BiteEffect());
+      this.registry.set('ホネこんぼう', new BoneClubEffect());
+      this.registry.set('たきのぼり', new WaterfallEffect());
+      this.registry.set('ゴッドバード', new SkyAttackEffect());
+      this.registry.set('いわなだれ', new RockSlideEffect());
+      this.registry.set('ひっさつまえば', new HyperFangEffect());
+      this.registry.set('ねこだまし', new FakeOutEffect());
+      this.registry.set('おどろかす', new AstonishEffect());
+      this.registry.set('ニードルアーム', new NeedleArmEffect());
+      this.registry.set('ドラゴンダイブ', new DragonRushEffect());
+      this.registry.set('しねんのずつき', new ZenHeadbuttEffect());
+      this.registry.set('アイアンヘッド', new IronHeadEffect());
+      this.registry.set('ハートスタンプ', new HeartStampEffect());
+      this.registry.set('ハードローラー', new SteamrollerEffect());
+      this.registry.set('つららおとし', new IcicleCrashEffect());
+      this.registry.set('びりびりちくちく', new ZingZapEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #126「物理カテゴリの未実装技の特殊効果: ひるみ付与 (19件)」**全件実装**。

### 実装した技
| 確率 | 技 |
|---|---|
| 30% | ふみつけ / まわしげり / ずつき / かみつく / ゴッドバード / いわなだれ / おどろかす / ニードルアーム / アイアンヘッド / ハートスタンプ / ハードローラー / つららおとし / びりびりちくちく |
| 20% | たきのぼり / ドラゴンダイブ / しねんのずつき |
| 10% | ホネこんぼう / ひっさつまえば |
| 100% | ねこだまし |

いずれも `BaseStatusConditionEffect` 継承（既存 `AirSlashEffect` と同パターン）。ひるみには免疫タイプなし。

### 注（保留した副次効果）
- **ゴッドバード**: 1ターンチャージは別処理（`IceBurnEffect` と同方針）
- **ねこだまし**: 「場に出た最初のターンのみ使用可能」制限は engine 未整備（turn counter / first-turn フラグが必要）。flinch part のみ実装

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛（`BaseStatusConditionEffect` の既存テストで網羅）。

Closes #126