### PR TITLE
feat: 変化カテゴリねむり関連の技効果を追加 (Issue #104)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/dark-void-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/dark-void-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ダークホール」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+
+ */
+export class DarkVoidEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/electric-terrain-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/electric-terrain-effect.ts
@@ -1,0 +1,35 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { Field } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * 「エレキフィールド」の特殊効果実装
+ *
+ * 効果: 5ターン間、地面にいるポケモンを眠り状態にできず、電気技の威力を1.5倍にする
+ *
+ * 注: 「眠り防止」「電気技 1.5倍」のダメージ計算側修正は別処理（engine 拡張）
+ */
+export class ElectricTerrainEffect implements IMoveEffect {
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const battle = battleContext.battle;
+
+    if (battle.field === Field.ElectricTerrain) {
+      return null;
+    }
+
+    await battleContext.battleRepository.update(battle.id, {
+      field: Field.ElectricTerrain,
+    });
+
+    return 'Electric Terrain was set up!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/grass-whistle-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/grass-whistle-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「くさぶえ」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+
+ */
+export class GrassWhistleEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/hypnosis-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/hypnosis-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「さいみんじゅつ」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+
+ */
+export class HypnosisEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/lovely-kiss-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/lovely-kiss-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「あくまのキッス」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+
+ */
+export class LovelyKissEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/rest-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/rest-effect.ts
@@ -1,0 +1,39 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ねむる」の特殊効果実装
+ *
+ * 効果: 自分の HP を全回復し、自分自身を眠り状態にする（本家では2ターン）
+ *
+ * 注: 本家では「2ターン固定で眠る」が、現状の engine では状態異常のターン経過管理が
+ *     未整備のため、眠り状態の付与のみを行う（眠りの起床処理は engine 側の責務）
+ */
+export class RestEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    // 既に HP 満タンかつ眠り状態なら失敗
+    if (
+      attacker.currentHp === attacker.maxHp &&
+      attacker.statusCondition === StatusCondition.Sleep
+    ) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      currentHp: attacker.maxHp,
+      statusCondition: StatusCondition.Sleep,
+    });
+
+    return 'user slept and recovered HP!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sing-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sing-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「うたう」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+
+ */
+export class SingEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = [];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/effects/spore-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/spore-effect.ts
@@ -1,0 +1,15 @@
+import { BaseStatusConditionEffect } from './base-status-condition-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「キノコのほうし」の特殊効果実装
+ *
+ * 効果: 必ず相手をねむり状態にする
+ * 制約: 粉技のためくさタイプには無効
+ */
+export class SporeEffect extends BaseStatusConditionEffect {
+  protected readonly statusCondition = StatusCondition.Sleep;
+  protected readonly chance = 1.0;
+  protected readonly immuneTypes: string[] = ['くさ'];
+  protected readonly message = 'fell asleep!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -138,6 +138,14 @@ import { HeartStampEffect } from './effects/heart-stamp-effect';
 import { SteamrollerEffect } from './effects/steamroller-effect';
 import { IcicleCrashEffect } from './effects/icicle-crash-effect';
 import { ZingZapEffect } from './effects/zing-zap-effect';
+import { SingEffect } from './effects/sing-effect';
+import { HypnosisEffect } from './effects/hypnosis-effect';
+import { LovelyKissEffect } from './effects/lovely-kiss-effect';
+import { SporeEffect } from './effects/spore-effect';
+import { GrassWhistleEffect } from './effects/grass-whistle-effect';
+import { DarkVoidEffect } from './effects/dark-void-effect';
+import { RestEffect } from './effects/rest-effect';
+import { ElectricTerrainEffect } from './effects/electric-terrain-effect';
 
 /**
  * 技のレジストリ
@@ -333,6 +341,15 @@ export class MoveRegistry {
       this.registry.set('ハードローラー', new SteamrollerEffect());
       this.registry.set('つららおとし', new IcicleCrashEffect());
       this.registry.set('びりびりちくちく', new ZingZapEffect());
+      // 変化カテゴリねむり関連（Issue #104）
+      this.registry.set('うたう', new SingEffect());
+      this.registry.set('さいみんじゅつ', new HypnosisEffect());
+      this.registry.set('あくまのキッス', new LovelyKissEffect());
+      this.registry.set('キノコのほうし', new SporeEffect());
+      this.registry.set('くさぶえ', new GrassWhistleEffect());
+      this.registry.set('ダークホール', new DarkVoidEffect());
+      this.registry.set('ねむる', new RestEffect());
+      this.registry.set('エレキフィールド', new ElectricTerrainEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #104「変化カテゴリの未実装技の特殊効果: ねむり付与 (11件)」のうち **8件を実装**。残る3件は engine 未整備のため保留。

### 実装した技
| 技 | 効果 |
|---|---|
| うたう / さいみんじゅつ / あくまのキッス / くさぶえ / ダークホール | 100% ねむり付与 |
| キノコのほうし | 100% ねむり（粉技、くさタイプ免疫） |
| ねむる | 自分の HP を全回復 + 自分を眠り状態にする |
| エレキフィールド | フィールドを Electric Terrain に変更（既存 `MistyTerrainEffect` パターン） |

### 設計メモ
- ねむり付与系6件は `BaseStatusConditionEffect` 継承（`SleepPowderEffect` と同パターン）
- ねむる は HP 全回復と眠り付与の両方を行うカスタム `IMoveEffect.onUse`
- エレキフィールドはフィールド変更のみ。「眠り防止」「電気技1.5倍」はダメージ計算側で別処理

### 保留した技（3件）
- **あくむ (Nightmare)**: 「眠っている相手に毎ターン最大HP 1/4 ダメージ」。状態異常に紐づく continuous-damage 機構が engine 未整備
- **ねごと (Sleep Talk)**: 「自分が眠っているときランダムに他の技を発動」。move-substitution が未整備
- **あくび (Yawn)**: 「次のターン終了時に相手を眠らせる」。delayed-status 機構が未整備

→ engine 拡張時にまとめて対応（continuous damage / move substitution / delayed status の各フックが必要）

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛。`BaseStatusConditionEffect` の既存テストで網羅、ねむる/エレキフィールドは `MistyTerrainEffect` と同形パターン。

Refs #104