### PR TITLE
feat: 変化カテゴリ「その他」の単一ステータス変化技を追加 (Issue #103一部、36件)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/acid-armor-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/acid-armor-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「とける」の特殊効果実装
+ */
+export class AcidArmorEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/agility-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/agility-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「こうそくいどう」の特殊効果実装
+ */
+export class AgilityEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/amnesia-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/amnesia-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ドわすれ」の特殊効果実装
+ */
+export class AmnesiaEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialDefense';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/autotomize-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/autotomize-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ボディパージ」の特殊効果実装
+ */
+export class AutotomizeEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/baby-doll-eyes-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/baby-doll-eyes-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「つぶらなひとみ」の特殊効果実装
+ */
+export class BabyDollEyesEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/barrier-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/barrier-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「バリアー」の特殊効果実装
+ */
+export class BarrierEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/charm-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/charm-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「あまえる」の特殊効果実装
+ */
+export class CharmEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/confide-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/confide-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ないしょばなし」の特殊効果実装
+ */
+export class ConfideEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/cotton-guard-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/cotton-guard-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「コットンガード」の特殊効果実装
+ */
+export class CottonGuardEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 3;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/cotton-spore-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/cotton-spore-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「わたほうし」の特殊効果実装
+ */
+export class CottonSporeEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/defense-curl-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/defense-curl-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「まるくなる」の特殊効果実装
+ */
+export class DefenseCurlEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/double-team-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/double-team-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「かげぶんしん」の特殊効果実装
+ */
+export class DoubleTeamEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'evasion';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/eerie-impulse-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/eerie-impulse-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「かいでんぱ」の特殊効果実装
+ */
+export class EerieImpulseEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/fake-tears-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/fake-tears-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「うそなき」の特殊効果実装
+ */
+export class FakeTearsEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialDefense';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/feather-dance-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/feather-dance-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「フェザーダンス」の特殊効果実装
+ */
+export class FeatherDanceEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/flash-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/flash-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「フラッシュ」の特殊効果実装
+ */
+export class FlashEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'accuracy';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/howl-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/howl-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「とおぼえ」の特殊効果実装
+ */
+export class HowlEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/iron-defense-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/iron-defense-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「てっぺき」の特殊効果実装
+ */
+export class IronDefenseEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/kinesis-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/kinesis-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「スプーンまげ」の特殊効果実装
+ */
+export class KinesisEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'accuracy';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/leer-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/leer-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「にらみつける」の特殊効果実装
+ */
+export class LeerEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/meditate-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/meditate-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ヨガのポーズ」の特殊効果実装
+ */
+export class MeditateEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/metal-sound-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/metal-sound-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「きんぞくおん」の特殊効果実装
+ */
+export class MetalSoundEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialDefense';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/minimize-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/minimize-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ちいさくなる」の特殊効果実装
+ */
+export class MinimizeEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'evasion';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/nasty-plot-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/nasty-plot-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「わるだくみ」の特殊効果実装
+ */
+export class NastyPlotEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/play-nice-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/play-nice-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「なかよくする」の特殊効果実装
+ */
+export class PlayNiceEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/rock-polish-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/rock-polish-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ロックカット」の特殊効果実装
+ */
+export class RockPolishEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = 2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sand-attack-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sand-attack-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「すなかけ」の特殊効果実装
+ */
+export class SandAttackEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'accuracy';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/scary-face-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/scary-face-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「こわいかお」の特殊効果実装
+ */
+export class ScaryFaceEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/screech-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/screech-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「いやなおと」の特殊効果実装
+ */
+export class ScreechEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sharpen-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sharpen-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「かくばる」の特殊効果実装
+ */
+export class SharpenEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'attack';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/smokescreen-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/smokescreen-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「えんまく」の特殊効果実装
+ */
+export class SmokescreenEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'accuracy';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/string-shot-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/string-shot-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「いとをはく」の特殊効果実装
+ */
+export class StringShotEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'speed';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/sweet-scent-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/sweet-scent-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「あまいかおり」の特殊効果実装
+ */
+export class SweetScentEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'evasion';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/tail-glow-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/tail-glow-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ほたるび」の特殊効果実装
+ */
+export class TailGlowEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = 3;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/tail-whip-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/tail-whip-effect.ts
@@ -1,0 +1,10 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「しっぽをふる」の特殊効果実装
+ */
+export class TailWhipEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/withdraw-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/withdraw-effect.ts
@@ -1,0 +1,10 @@
+import { BaseSelfStatChangeMoveEffect } from './base/base-self-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「からにこもる」の特殊効果実装
+ */
+export class WithdrawEffect extends BaseSelfStatChangeMoveEffect {
+  protected readonly statType: StatType = 'defense';
+  protected readonly rankChange = 1;
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -146,6 +146,43 @@ import { GrassWhistleEffect } from './effects/grass-whistle-effect';
 import { DarkVoidEffect } from './effects/dark-void-effect';
 import { RestEffect } from './effects/rest-effect';
 import { ElectricTerrainEffect } from './effects/electric-terrain-effect';
+// Issue #103: 単一ステータス変化系
+import { MeditateEffect } from './effects/meditate-effect';
+import { SharpenEffect } from './effects/sharpen-effect';
+import { HowlEffect } from './effects/howl-effect';
+import { WithdrawEffect } from './effects/withdraw-effect';
+import { DefenseCurlEffect } from './effects/defense-curl-effect';
+import { DoubleTeamEffect } from './effects/double-team-effect';
+import { AgilityEffect } from './effects/agility-effect';
+import { AmnesiaEffect } from './effects/amnesia-effect';
+import { AcidArmorEffect } from './effects/acid-armor-effect';
+import { BarrierEffect } from './effects/barrier-effect';
+import { IronDefenseEffect } from './effects/iron-defense-effect';
+import { MinimizeEffect } from './effects/minimize-effect';
+import { RockPolishEffect } from './effects/rock-polish-effect';
+import { NastyPlotEffect } from './effects/nasty-plot-effect';
+import { AutotomizeEffect } from './effects/autotomize-effect';
+import { TailGlowEffect } from './effects/tail-glow-effect';
+import { CottonGuardEffect } from './effects/cotton-guard-effect';
+import { SandAttackEffect } from './effects/sand-attack-effect';
+import { TailWhipEffect } from './effects/tail-whip-effect';
+import { LeerEffect } from './effects/leer-effect';
+import { KinesisEffect } from './effects/kinesis-effect';
+import { FlashEffect } from './effects/flash-effect';
+import { SmokescreenEffect } from './effects/smokescreen-effect';
+import { SweetScentEffect } from './effects/sweet-scent-effect';
+import { PlayNiceEffect } from './effects/play-nice-effect';
+import { BabyDollEyesEffect } from './effects/baby-doll-eyes-effect';
+import { ConfideEffect } from './effects/confide-effect';
+import { StringShotEffect } from './effects/string-shot-effect';
+import { ScreechEffect } from './effects/screech-effect';
+import { CottonSporeEffect } from './effects/cotton-spore-effect';
+import { ScaryFaceEffect } from './effects/scary-face-effect';
+import { CharmEffect } from './effects/charm-effect';
+import { FeatherDanceEffect } from './effects/feather-dance-effect';
+import { FakeTearsEffect } from './effects/fake-tears-effect';
+import { MetalSoundEffect } from './effects/metal-sound-effect';
+import { EerieImpulseEffect } from './effects/eerie-impulse-effect';
 
 /**
  * 技のレジストリ
@@ -350,6 +387,45 @@ export class MoveRegistry {
       this.registry.set('ダークホール', new DarkVoidEffect());
       this.registry.set('ねむる', new RestEffect());
       this.registry.set('エレキフィールド', new ElectricTerrainEffect());
+      // 変化カテゴリ「その他」: 単一ステータス変化系（Issue #103 一部）
+      // 自分の能力上昇
+      this.registry.set('ヨガのポーズ', new MeditateEffect());
+      this.registry.set('かくばる', new SharpenEffect());
+      this.registry.set('とおぼえ', new HowlEffect());
+      this.registry.set('からにこもる', new WithdrawEffect());
+      this.registry.set('まるくなる', new DefenseCurlEffect());
+      this.registry.set('かげぶんしん', new DoubleTeamEffect());
+      this.registry.set('こうそくいどう', new AgilityEffect());
+      this.registry.set('ドわすれ', new AmnesiaEffect());
+      this.registry.set('とける', new AcidArmorEffect());
+      this.registry.set('バリアー', new BarrierEffect());
+      this.registry.set('てっぺき', new IronDefenseEffect());
+      this.registry.set('ちいさくなる', new MinimizeEffect());
+      this.registry.set('ロックカット', new RockPolishEffect());
+      this.registry.set('わるだくみ', new NastyPlotEffect());
+      this.registry.set('ボディパージ', new AutotomizeEffect());
+      this.registry.set('ほたるび', new TailGlowEffect());
+      this.registry.set('コットンガード', new CottonGuardEffect());
+      // 相手の能力下降
+      this.registry.set('すなかけ', new SandAttackEffect());
+      this.registry.set('しっぽをふる', new TailWhipEffect());
+      this.registry.set('にらみつける', new LeerEffect());
+      this.registry.set('スプーンまげ', new KinesisEffect());
+      this.registry.set('フラッシュ', new FlashEffect());
+      this.registry.set('えんまく', new SmokescreenEffect());
+      this.registry.set('あまいかおり', new SweetScentEffect());
+      this.registry.set('なかよくする', new PlayNiceEffect());
+      this.registry.set('つぶらなひとみ', new BabyDollEyesEffect());
+      this.registry.set('ないしょばなし', new ConfideEffect());
+      this.registry.set('いとをはく', new StringShotEffect());
+      this.registry.set('いやなおと', new ScreechEffect());
+      this.registry.set('わたほうし', new CottonSporeEffect());
+      this.registry.set('こわいかお', new ScaryFaceEffect());
+      this.registry.set('あまえる', new CharmEffect());
+      this.registry.set('フェザーダンス', new FeatherDanceEffect());
+      this.registry.set('うそなき', new FakeTearsEffect());
+      this.registry.set('きんぞくおん', new MetalSoundEffect());
+      this.registry.set('かいでんぱ', new EerieImpulseEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #103（変化カテゴリ「その他」127件）のうち、単一ステータス変化に集約できる **36件を実装**。残り91件は別パターン（マルチステ変化・特殊機構・engine 未整備）のため別 PR で対応。

### 実装内容
既存 `BaseSelfStatChangeMoveEffect` / `BaseOpponentStatChangeMoveEffect` を継承するだけの最小実装。

#### 自分の能力上昇（17件）
| ランク | 技 |
|---|---|
| +1 | ヨガのポーズ(攻) / かくばる(攻) / とおぼえ(攻) / からにこもる(防) / まるくなる(防) / かげぶんしん(回避) |
| +2 | こうそくいどう(速) / ドわすれ(特防) / とける(防) / バリアー(防) / てっぺき(防) / ちいさくなる(回避) / ロックカット(速) / わるだくみ(特攻) / ボディパージ(速) |
| +3 | ほたるび(特攻) / コットンガード(防) |

#### 相手の能力下降（19件）
| ランク | 技 |
|---|---|
| -1 | すなかけ(命中) / しっぽをふる(防) / にらみつける(防) / スプーンまげ(命中) / フラッシュ(命中) / えんまく(命中) / あまいかおり(回避) / なかよくする(攻) / つぶらなひとみ(攻) / ないしょばなし(特攻) |
| -2 | いとをはく(速) / いやなおと(防) / わたほうし(速) / こわいかお(速) / あまえる(攻) / フェザーダンス(攻) / うそなき(特防) / きんぞくおん(特防) / かいでんぱ(特攻) |

### 設計メモ
- いずれも `statType` と `rankChange` を設定するだけの 9〜10行のクラス
- 既存 base のテストで挙動は網羅されており、個別 spec は割愛
- 副次効果（ボディパージの「重さ半減」等）は engine 未整備のため別処理

### 残課題（#103 で未実装）
- マルチステ変化（せいちょう / コスモパワー / ビルドアップ / りゅうのまい / ちょうのまい / からをやぶる 等）
- 命中保証（こころのめ / ロックオン）、技模倣（ものまね / ゆびをふる / ねこのて）、能力交換（スキルスワップ / パワースワップ）など engine 未整備の機構を要するもの

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass（再実行で安定、`エアスラッシュ30%` の確率テスト flake は既存問題）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #103