### PR TITLE
feat: 変化カテゴリ「その他」の複数ステータス変化技を追加 (Issue #103一部、15件)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/base/base-opponent-multi-stat-change-move-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-opponent-multi-stat-change-move-effect.ts
@@ -1,0 +1,46 @@
+import { IMoveEffect } from '../../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../../abilities/battle-context.interface';
+import { StatType, STAT_RANK_PROP_MAP, STAT_NAME_MAP } from './base-stat-change-effect';
+
+/**
+ * 相手の複数ステータスランクを変更する変化技の基底クラス
+ *
+ * 例: くすぐる（攻撃-1, 防御-1）、おたけび（攻撃-1, 特攻-1）
+ */
+export abstract class BaseOpponentMultiStatChangeMoveEffect implements IMoveEffect {
+  protected abstract readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }>;
+
+  async onUse(
+    _attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const updateData: Partial<BattlePokemonStatus> = {};
+    const messages: string[] = [];
+
+    for (const { statType, rankChange } of this.statChanges) {
+      const currentRank = defender.getStatRank(statType);
+      const newRank = Math.max(-6, Math.min(6, currentRank + rankChange));
+      if (newRank === currentRank) {
+        continue;
+      }
+      const propName = STAT_RANK_PROP_MAP[statType];
+      (updateData as Record<string, number>)[propName] = newRank;
+      const statName = STAT_NAME_MAP[statType];
+      const direction = rankChange > 0 ? 'rose' : 'fell';
+      messages.push(`${statName} ${direction}!`);
+    }
+
+    if (messages.length === 0) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, updateData);
+    return messages.join(' ');
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-self-multi-stat-change-move-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-self-multi-stat-change-move-effect.spec.ts
@@ -1,0 +1,129 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base-self-multi-stat-change-move-effect';
+import { StatType } from './base-stat-change-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestGrowth extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'specialAttack', rankChange: 1 },
+  ];
+}
+
+class TestShellSmash extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 2 },
+    { statType: 'specialAttack', rankChange: 2 },
+    { statType: 'speed', rankChange: 2 },
+    { statType: 'defense', rankChange: -1 },
+    { statType: 'specialDefense', rankChange: -1 },
+  ];
+}
+
+describe('BaseSelfMultiStatChangeMoveEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('Growth 相当: 攻撃+1, 特攻+1 を同時適用', async () => {
+    const effect = new TestGrowth();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('Attack rose! Special Attack rose!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      attackRank: 1,
+      specialAttackRank: 1,
+    });
+  });
+
+  it('Shell Smash 相当: 3つ上昇 + 2つ下降を一度に適用', async () => {
+    const effect = new TestShellSmash();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toContain('Attack rose!');
+    expect(result).toContain('Defense fell!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      attackRank: 2,
+      specialAttackRank: 2,
+      speedRank: 2,
+      defenseRank: -1,
+      specialDefenseRank: -1,
+    });
+  });
+
+  it('一部のステが上限に達していてもその他は変化する', async () => {
+    const effect = new TestGrowth();
+    const attacker = createBattlePokemonStatus({ attackRank: 6 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('Special Attack rose!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      specialAttackRank: 1,
+    });
+  });
+
+  it('全てのステが上限/下限なら null', async () => {
+    const effect = new TestGrowth();
+    const attacker = createBattlePokemonStatus({ attackRank: 6, specialAttackRank: 6 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は null', async () => {
+    const effect = new TestGrowth();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-self-multi-stat-change-move-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-self-multi-stat-change-move-effect.ts
@@ -1,0 +1,52 @@
+import { IMoveEffect } from '../../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../../abilities/battle-context.interface';
+import { StatType, STAT_RANK_PROP_MAP, STAT_NAME_MAP } from './base-stat-change-effect';
+
+/**
+ * 自分の複数ステータスランクを変更する変化技の基底クラス
+ *
+ * 例: せいちょう（攻撃+1, 特攻+1）、ちょうのまい（特攻+1, 特防+1, 素早さ+1）
+ *
+ * - 各ステータス変化は独立して試行（一つが既に上限/下限でも他は変化する）
+ * - 上昇/下降は statChanges 配列で個別に指定可能（からをやぶる等の混在型に対応）
+ */
+export abstract class BaseSelfMultiStatChangeMoveEffect implements IMoveEffect {
+  /**
+   * 変更するステータスとランク変化の組み合わせ
+   */
+  protected abstract readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }>;
+
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const updateData: Partial<BattlePokemonStatus> = {};
+    const messages: string[] = [];
+
+    for (const { statType, rankChange } of this.statChanges) {
+      const currentRank = attacker.getStatRank(statType);
+      const newRank = Math.max(-6, Math.min(6, currentRank + rankChange));
+      if (newRank === currentRank) {
+        continue;
+      }
+      const propName = STAT_RANK_PROP_MAP[statType];
+      (updateData as Record<string, number>)[propName] = newRank;
+      const statName = STAT_NAME_MAP[statType];
+      const direction = rankChange > 0 ? 'rose' : 'fell';
+      messages.push(`${statName} ${direction}!`);
+    }
+
+    if (messages.length === 0) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, updateData);
+    return messages.join(' ');
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/bulk-up-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/bulk-up-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ビルドアップ」の特殊効果実装
+ */
+export class BulkUpEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'defense', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/calm-mind-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/calm-mind-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「めいそう」の特殊効果実装
+ */
+export class CalmMindEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'specialAttack', rankChange: 1 },
+    { statType: 'specialDefense', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/coil-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/coil-effect.ts
@@ -1,0 +1,13 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「とぐろをまく」の特殊効果実装
+ */
+export class CoilEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'defense', rankChange: 1 },
+    { statType: 'accuracy', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/cosmic-power-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/cosmic-power-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「コスモパワー」の特殊効果実装
+ */
+export class CosmicPowerEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'defense', rankChange: 1 },
+    { statType: 'specialDefense', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/defend-order-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/defend-order-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ぼうぎょしれい」の特殊効果実装
+ */
+export class DefendOrderEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'defense', rankChange: 1 },
+    { statType: 'specialDefense', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/dragon-dance-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/dragon-dance-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「りゅうのまい」の特殊効果実装
+ */
+export class DragonDanceEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'speed', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/growth-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/growth-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「せいちょう」の特殊効果実装
+ */
+export class GrowthEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'specialAttack', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/hone-claws-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/hone-claws-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「つめとぎ」の特殊効果実装
+ */
+export class HoneClawsEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'accuracy', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/noble-roar-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/noble-roar-effect.ts
@@ -1,0 +1,12 @@
+import { BaseOpponentMultiStatChangeMoveEffect } from './base/base-opponent-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「おたけび」の特殊効果実装
+ */
+export class NobleRoarEffect extends BaseOpponentMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: -1 },
+    { statType: 'specialAttack', rankChange: -1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/quiver-dance-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/quiver-dance-effect.ts
@@ -1,0 +1,13 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ちょうのまい」の特殊効果実装
+ */
+export class QuiverDanceEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'specialAttack', rankChange: 1 },
+    { statType: 'specialDefense', rankChange: 1 },
+    { statType: 'speed', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/shell-smash-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/shell-smash-effect.ts
@@ -1,0 +1,15 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「からをやぶる」の特殊効果実装
+ */
+export class ShellSmashEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 2 },
+    { statType: 'specialAttack', rankChange: 2 },
+    { statType: 'speed', rankChange: 2 },
+    { statType: 'defense', rankChange: -1 },
+    { statType: 'specialDefense', rankChange: -1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/shift-gear-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/shift-gear-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ギアチェンジ」の特殊効果実装
+ */
+export class ShiftGearEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'speed', rankChange: 2 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/tearful-look-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/tearful-look-effect.ts
@@ -1,0 +1,12 @@
+import { BaseOpponentMultiStatChangeMoveEffect } from './base/base-opponent-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「なみだめ」の特殊効果実装
+ */
+export class TearfulLookEffect extends BaseOpponentMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: -1 },
+    { statType: 'specialAttack', rankChange: -1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/tickle-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/tickle-effect.ts
@@ -1,0 +1,12 @@
+import { BaseOpponentMultiStatChangeMoveEffect } from './base/base-opponent-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「くすぐる」の特殊効果実装
+ */
+export class TickleEffect extends BaseOpponentMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: -1 },
+    { statType: 'defense', rankChange: -1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/effects/work-up-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/work-up-effect.ts
@@ -1,0 +1,12 @@
+import { BaseSelfMultiStatChangeMoveEffect } from './base/base-self-multi-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ふるいたてる」の特殊効果実装
+ */
+export class WorkUpEffect extends BaseSelfMultiStatChangeMoveEffect {
+  protected readonly statChanges: ReadonlyArray<{ statType: StatType; rankChange: number }> = [
+    { statType: 'attack', rankChange: 1 },
+    { statType: 'specialAttack', rankChange: 1 },
+  ];
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -183,6 +183,22 @@ import { FeatherDanceEffect } from './effects/feather-dance-effect';
 import { FakeTearsEffect } from './effects/fake-tears-effect';
 import { MetalSoundEffect } from './effects/metal-sound-effect';
 import { EerieImpulseEffect } from './effects/eerie-impulse-effect';
+// Issue #103: 複数ステータス変化系
+import { GrowthEffect } from './effects/growth-effect';
+import { CosmicPowerEffect } from './effects/cosmic-power-effect';
+import { BulkUpEffect } from './effects/bulk-up-effect';
+import { CalmMindEffect } from './effects/calm-mind-effect';
+import { DragonDanceEffect } from './effects/dragon-dance-effect';
+import { DefendOrderEffect } from './effects/defend-order-effect';
+import { HoneClawsEffect } from './effects/hone-claws-effect';
+import { WorkUpEffect } from './effects/work-up-effect';
+import { QuiverDanceEffect } from './effects/quiver-dance-effect';
+import { CoilEffect } from './effects/coil-effect';
+import { ShiftGearEffect } from './effects/shift-gear-effect';
+import { ShellSmashEffect } from './effects/shell-smash-effect';
+import { TickleEffect } from './effects/tickle-effect';
+import { NobleRoarEffect } from './effects/noble-roar-effect';
+import { TearfulLookEffect } from './effects/tearful-look-effect';
 
 /**
  * 技のレジストリ
@@ -426,6 +442,22 @@ export class MoveRegistry {
       this.registry.set('うそなき', new FakeTearsEffect());
       this.registry.set('きんぞくおん', new MetalSoundEffect());
       this.registry.set('かいでんぱ', new EerieImpulseEffect());
+      // 変化カテゴリ「その他」: 複数ステータス変化系（Issue #103 一部）
+      this.registry.set('せいちょう', new GrowthEffect());
+      this.registry.set('コスモパワー', new CosmicPowerEffect());
+      this.registry.set('ビルドアップ', new BulkUpEffect());
+      this.registry.set('めいそう', new CalmMindEffect());
+      this.registry.set('りゅうのまい', new DragonDanceEffect());
+      this.registry.set('ぼうぎょしれい', new DefendOrderEffect());
+      this.registry.set('つめとぎ', new HoneClawsEffect());
+      this.registry.set('ふるいたてる', new WorkUpEffect());
+      this.registry.set('ちょうのまい', new QuiverDanceEffect());
+      this.registry.set('とぐろをまく', new CoilEffect());
+      this.registry.set('ギアチェンジ', new ShiftGearEffect());
+      this.registry.set('からをやぶる', new ShellSmashEffect());
+      this.registry.set('くすぐる', new TickleEffect());
+      this.registry.set('おたけび', new NobleRoarEffect());
+      this.registry.set('なみだめ', new TearfulLookEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #103 の続編。**複数ステータス変化に集約できる15件**を実装。汎用 base class を新規追加し、メモリ・コード重複を最小化。

### 新規 base
| Base | 用途 |
|---|---|
| `BaseSelfMultiStatChangeMoveEffect` | 自分の複数能力ランクを一括変化 |
| `BaseOpponentMultiStatChangeMoveEffect` | 相手の複数能力ランクを一括変化 |

派生クラスは `statChanges: ReadonlyArray<{ statType, rankChange }>` を設定するだけ。各ステ変化は独立試行（一部上限/下限でも他は変化）。

### 実装した技

#### 自分の能力複数上昇/混在（12件）
| 技 | 効果 |
|---|---|
| せいちょう | 攻+1 / 特攻+1 |
| コスモパワー | 防+1 / 特防+1 |
| ビルドアップ | 攻+1 / 防+1 |
| めいそう | 特攻+1 / 特防+1 |
| りゅうのまい | 攻+1 / 速+1 |
| ぼうぎょしれい | 防+1 / 特防+1 |
| つめとぎ | 攻+1 / 命中+1 |
| ふるいたてる | 攻+1 / 特攻+1 |
| ちょうのまい | 特攻+1 / 特防+1 / 速+1 |
| とぐろをまく | 攻+1 / 防+1 / 命中+1 |
| ギアチェンジ | 攻+1 / 速+2 |
| からをやぶる | 攻+2 / 特攻+2 / 速+2 / 防-1 / 特防-1（混在型） |

#### 相手の能力複数下降（3件）
| 技 | 効果 |
|---|---|
| くすぐる | 攻-1 / 防-1 |
| おたけび | 攻-1 / 特攻-1 |
| なみだめ | 攻-1 / 特攻-1 |

## Test plan
- [x] `base-self-multi-stat-change-move-effect.spec.ts` 追加: 5ケース（Growth相当・Shell Smash混在型・一部上限・全上限・リポジトリ無し）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 派生クラスは設定値のみ。挙動は base spec で網羅。

Refs #103