### PR TITLE
feat: 変化カテゴリ「その他」の HP 操作系を追加 (Issue #103一部、3件)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/belly-drum-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/belly-drum-effect.spec.ts
@@ -1,0 +1,77 @@
+import { BellyDrumEffect } from './belly-drum-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('BellyDrumEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('HP 1/2 を支払い、攻撃ランクを +6 にする', async () => {
+    const effect = new BellyDrumEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 100, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('user cut its HP and maxed its Attack!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 50,
+      attackRank: 6,
+    });
+  });
+
+  it('HP が最大 HP の 1/2 以下なら失敗', async () => {
+    const effect = new BellyDrumEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 50, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('既に攻撃ランクが +6 なら失敗', async () => {
+    const effect = new BellyDrumEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 100, maxHp: 100, attackRank: 6 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/belly-drum-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/belly-drum-effect.ts
@@ -1,0 +1,38 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「はらだいこ」の特殊効果実装
+ *
+ * 効果: 自分の最大 HP の 1/2 を払い、攻撃ランクを最大（+6）にする
+ *
+ * - 現在 HP が最大 HP の 1/2 以下の場合は失敗
+ * - 既に攻撃ランクが +6 の場合は失敗（HP も減らない、本家挙動）
+ */
+export class BellyDrumEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const hpCost = Math.floor(attacker.maxHp / 2);
+    if (attacker.currentHp <= hpCost) {
+      return null;
+    }
+    if (attacker.attackRank >= 6) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      currentHp: attacker.currentHp - hpCost,
+      attackRank: 6,
+    });
+
+    return 'user cut its HP and maxed its Attack!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/memento-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/memento-effect.spec.ts
@@ -1,0 +1,98 @@
+import { MementoEffect } from './memento-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('MementoEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('相手の攻撃・特攻を -2、自分は瀕死', async () => {
+    const effect = new MementoEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 100, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2, attackRank: 0, specialAttackRank: 0 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe("target's Attack and Special Attack fell! User fainted!");
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      attackRank: -2,
+      specialAttackRank: -2,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 0,
+    });
+  });
+
+  it('相手の能力ランクが既に -6 でも自分は瀕死する', async () => {
+    const effect = new MementoEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 50, maxHp: 100 });
+    const defender = createBattlePokemonStatus({
+      id: 2,
+      attackRank: -6,
+      specialAttackRank: -6,
+    });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe("target's Attack and Special Attack fell! User fainted!");
+    // 相手の能力は既に下限のため変更されない
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalledWith(
+      defender.id,
+      expect.objectContaining({ attackRank: expect.any(Number) }),
+    );
+    // 自分は瀕死する
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 0,
+    });
+  });
+
+  it('-6 でクランプ', async () => {
+    const effect = new MementoEffect();
+    const attacker = createBattlePokemonStatus();
+    const defender = createBattlePokemonStatus({
+      id: 2,
+      attackRank: -5,
+      specialAttackRank: -5,
+    });
+    const ctx = createBattleContext();
+
+    await effect.onUse(attacker, defender, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      attackRank: -6,
+      specialAttackRank: -6,
+    });
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/memento-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/memento-effect.ts
@@ -1,0 +1,44 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「おきみやげ」の特殊効果実装
+ *
+ * 効果: 相手の攻撃と特攻を 2 段階下げ、自分は HP0 で瀕死する
+ *
+ * 注: ひんし後の交代・処理（次のポケモン繰り出し等）はバトルフロー側の責務
+ */
+export class MementoEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const newAttackRank = Math.max(-6, defender.attackRank - 2);
+    const newSpecialAttackRank = Math.max(-6, defender.specialAttackRank - 2);
+
+    const defenderUpdate: Partial<BattlePokemonStatus> = {};
+    if (newAttackRank !== defender.attackRank) {
+      (defenderUpdate as Record<string, number>).attackRank = newAttackRank;
+    }
+    if (newSpecialAttackRank !== defender.specialAttackRank) {
+      (defenderUpdate as Record<string, number>).specialAttackRank = newSpecialAttackRank;
+    }
+
+    if (Object.keys(defenderUpdate).length > 0) {
+      await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, defenderUpdate);
+    }
+
+    // 自分は瀕死
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      currentHp: 0,
+    });
+
+    return "target's Attack and Special Attack fell! User fainted!";
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/pain-split-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/pain-split-effect.spec.ts
@@ -1,0 +1,85 @@
+import { PainSplitEffect } from './pain-split-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('PainSplitEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('自分と相手の HP を平均値にする', async () => {
+    const effect = new PainSplitEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 20, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2, currentHp: 80, maxHp: 100 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('HP was averaged with the target!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 50,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      currentHp: 50,
+    });
+  });
+
+  it('一方の最大 HP を超えないようクランプ', async () => {
+    const effect = new PainSplitEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 100, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2, currentHp: 50, maxHp: 50 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBe('HP was averaged with the target!');
+    // 平均は (100+50)/2 = 75 だが defender.maxHp=50 なので 50 にクランプ
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 75,
+    });
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+      currentHp: 50,
+    });
+  });
+
+  it('HP が同じなら何もしない', async () => {
+    const effect = new PainSplitEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 50, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2, currentHp: 50, maxHp: 100 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/pain-split-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/pain-split-effect.ts
@@ -1,0 +1,39 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「いたみわけ」の特殊効果実装
+ *
+ * 効果: 自分と相手の現在 HP を平均値にする
+ *       両者の HP を上限（それぞれの maxHp）でクランプ
+ */
+export class PainSplitEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const averagedHp = Math.floor((attacker.currentHp + defender.currentHp) / 2);
+    const newAttackerHp = Math.min(averagedHp, attacker.maxHp);
+    const newDefenderHp = Math.min(averagedHp, defender.maxHp);
+
+    // 両者とも変化が無ければ何もしない
+    if (newAttackerHp === attacker.currentHp && newDefenderHp === defender.currentHp) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      currentHp: newAttackerHp,
+    });
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      currentHp: newDefenderHp,
+    });
+
+    return 'HP was averaged with the target!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -199,6 +199,9 @@ import { ShellSmashEffect } from './effects/shell-smash-effect';
 import { TickleEffect } from './effects/tickle-effect';
 import { NobleRoarEffect } from './effects/noble-roar-effect';
 import { TearfulLookEffect } from './effects/tearful-look-effect';
+import { BellyDrumEffect } from './effects/belly-drum-effect';
+import { PainSplitEffect } from './effects/pain-split-effect';
+import { MementoEffect } from './effects/memento-effect';
 
 /**
  * 技のレジストリ
@@ -458,6 +461,10 @@ export class MoveRegistry {
       this.registry.set('くすぐる', new TickleEffect());
       this.registry.set('おたけび', new NobleRoarEffect());
       this.registry.set('なみだめ', new TearfulLookEffect());
+      // 変化カテゴリ「その他」: HP 操作系（Issue #103 一部）
+      this.registry.set('はらだいこ', new BellyDrumEffect());
+      this.registry.set('いたみわけ', new PainSplitEffect());
+      this.registry.set('おきみやげ', new MementoEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #103 の続編。**HP 操作を含む3件**を実装。

| 技 | 効果 |
|---|---|
| はらだいこ | 自分の最大 HP の 1/2 を支払い、攻撃ランクを +6 にする |
| いたみわけ | 自分と相手の現在 HP を平均値にする（両者の maxHp でクランプ） |
| おきみやげ | 相手の攻撃・特攻を -2 し、自分は HP 0 になる |

### 設計メモ
- いずれも HP 操作を含むため共通 base に集約せず個別カスタム実装
- はらだいこ: HP が不足 / 既に +6 のときは失敗（本家挙動）
- いたみわけ: 平均が片方の maxHp を超える場合はクランプ（不利な側だけが回復する正しい挙動）
- おきみやげ: 相手の能力が既に下限でも、自分の瀕死は実行される。瀕死後の交代処理は engine 側の責務

## Test plan
- [x] `belly-drum-effect.spec.ts`: 3ケース（成功/HP不足/+6既存）
- [x] `pain-split-effect.spec.ts`: 3ケース（平均化/maxHp クランプ/同 HP）
- [x] `memento-effect.spec.ts`: 3ケース（通常/相手既に -6/-6 クランプ）
- [x] `npm test`: 122 suites / 700 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #103