### PR TITLE
feat: 変化カテゴリ「その他」のランク交換/HP操作系を追加 (Issue #103一部、4件)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/fillet-away-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/fillet-away-effect.spec.ts
@@ -1,0 +1,85 @@
+import { FilletAwayEffect } from './fillet-away-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('FilletAwayEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('HP 1/2 を支払い、攻撃・特攻・素早さを +2 する', async () => {
+    const effect = new FilletAwayEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 100, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toMatch(/cut its HP/);
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      currentHp: 50,
+      attackRank: 2,
+      specialAttackRank: 2,
+      speedRank: 2,
+    });
+  });
+
+  it('HP が不足するなら失敗', async () => {
+    const effect = new FilletAwayEffect();
+    const attacker = createBattlePokemonStatus({ currentHp: 30, maxHp: 100 });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('既に攻撃/特攻/素早さが +6 なら失敗', async () => {
+    const effect = new FilletAwayEffect();
+    const attacker = createBattlePokemonStatus({
+      currentHp: 100,
+      maxHp: 100,
+      attackRank: 6,
+      specialAttackRank: 6,
+      speedRank: 6,
+    });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/fillet-away-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/fillet-away-effect.ts
@@ -1,0 +1,49 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「みをけずる」の特殊効果実装
+ *
+ * 効果: 最大 HP の 1/2 を支払い、攻撃・特攻・素早さを 2 段階ずつ上昇させる
+ *
+ * - HP が不足する場合は失敗
+ * - 攻撃/特攻/素早さが全て既に +6 の場合は失敗
+ */
+export class FilletAwayEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const hpCost = Math.floor(attacker.maxHp / 2);
+    if (attacker.currentHp <= hpCost) {
+      return null;
+    }
+
+    const newAttackRank = Math.min(6, attacker.attackRank + 2);
+    const newSpecialAttackRank = Math.min(6, attacker.specialAttackRank + 2);
+    const newSpeedRank = Math.min(6, attacker.speedRank + 2);
+
+    if (
+      newAttackRank === attacker.attackRank &&
+      newSpecialAttackRank === attacker.specialAttackRank &&
+      newSpeedRank === attacker.speedRank
+    ) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      currentHp: attacker.currentHp - hpCost,
+      attackRank: newAttackRank,
+      specialAttackRank: newSpecialAttackRank,
+      speedRank: newSpeedRank,
+    });
+
+    return 'user cut its HP and sharply raised Attack, Special Attack, and Speed!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/guard-swap-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/guard-swap-effect.ts
@@ -1,0 +1,34 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「ガードスワップ」の特殊効果実装
+ *
+ * 効果: ユーザーと相手の「防御」と「特防」のランク変化を交換する
+ */
+export class GuardSwapEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const attackerDefense = attacker.defenseRank;
+    const attackerSpecialDefense = attacker.specialDefenseRank;
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      defenseRank: attackerDefense,
+      specialDefenseRank: attackerSpecialDefense,
+    });
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      defenseRank: defender.defenseRank,
+      specialDefenseRank: defender.specialDefenseRank,
+    });
+
+    return 'The user swapped Defense and Special Defense changes with the target!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/power-swap-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/power-swap-effect.spec.ts
@@ -1,0 +1,107 @@
+import { PowerSwapEffect } from './power-swap-effect';
+import { GuardSwapEffect } from './guard-swap-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('Power/Guard Swap', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  describe('PowerSwapEffect', () => {
+    it('攻撃・特攻のランクを相手と交換する', async () => {
+      const effect = new PowerSwapEffect();
+      const attacker = createBattlePokemonStatus({ attackRank: 2, specialAttackRank: 3 });
+      const defender = createBattlePokemonStatus({
+        id: 2,
+        attackRank: -1,
+        specialAttackRank: -2,
+      });
+      const ctx = createBattleContext();
+
+      await effect.onUse(attacker, defender, ctx);
+
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        attackRank: 2,
+        specialAttackRank: 3,
+      });
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+        attackRank: -1,
+        specialAttackRank: -2,
+      });
+    });
+
+    it('他の能力ランクは変更しない', async () => {
+      const effect = new PowerSwapEffect();
+      const attacker = createBattlePokemonStatus({
+        attackRank: 1,
+        specialAttackRank: 1,
+        defenseRank: 5,
+        speedRank: 5,
+      });
+      const defender = createBattlePokemonStatus({ id: 2 });
+      const ctx = createBattleContext();
+
+      await effect.onUse(attacker, defender, ctx);
+
+      const calls = (ctx.battleRepository?.updateBattlePokemonStatus as jest.Mock).mock.calls;
+      for (const [, update] of calls) {
+        expect(update).not.toHaveProperty('defenseRank');
+        expect(update).not.toHaveProperty('speedRank');
+      }
+    });
+  });
+
+  describe('GuardSwapEffect', () => {
+    it('防御・特防のランクを相手と交換する', async () => {
+      const effect = new GuardSwapEffect();
+      const attacker = createBattlePokemonStatus({ defenseRank: 3, specialDefenseRank: 2 });
+      const defender = createBattlePokemonStatus({
+        id: 2,
+        defenseRank: -1,
+        specialDefenseRank: 0,
+      });
+      const ctx = createBattleContext();
+
+      await effect.onUse(attacker, defender, ctx);
+
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(defender.id, {
+        defenseRank: 3,
+        specialDefenseRank: 2,
+      });
+      expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+        defenseRank: -1,
+        specialDefenseRank: 0,
+      });
+    });
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/power-swap-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/power-swap-effect.ts
@@ -1,0 +1,34 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+
+/**
+ * 「パワースワップ」の特殊効果実装
+ *
+ * 効果: ユーザーと相手の「攻撃」と「特攻」のランク変化を交換する
+ */
+export class PowerSwapEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const attackerAttack = attacker.attackRank;
+    const attackerSpecialAttack = attacker.specialAttackRank;
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(defender.id, {
+      attackRank: attackerAttack,
+      specialAttackRank: attackerSpecialAttack,
+    });
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, {
+      attackRank: defender.attackRank,
+      specialAttackRank: defender.specialAttackRank,
+    });
+
+    return 'The user swapped Attack and Special Attack changes with the target!';
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/effects/take-heart-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/take-heart-effect.spec.ts
@@ -1,0 +1,89 @@
+import { TakeHeartEffect } from './take-heart-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('TakeHeartEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 100,
+      overrides?.maxHp ?? 100,
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('状態異常を治癒し、特攻と特防を +1 する', async () => {
+    const effect = new TakeHeartEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: StatusCondition.Burn });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toContain('cured of its status');
+    expect(result).toContain('Special Attack rose!');
+    expect(result).toContain('Special Defense rose!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      statusCondition: StatusCondition.None,
+      specialAttackRank: 1,
+      specialDefenseRank: 1,
+    });
+  });
+
+  it('状態異常が無い場合は能力上昇のみ', async () => {
+    const effect = new TakeHeartEffect();
+    const attacker = createBattlePokemonStatus({ statusCondition: null });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).not.toContain('cured');
+    expect(result).toContain('Special Attack rose!');
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(attacker.id, {
+      specialAttackRank: 1,
+      specialDefenseRank: 1,
+    });
+  });
+
+  it('能力が既に上限で状態異常も無いなら null', async () => {
+    const effect = new TakeHeartEffect();
+    const attacker = createBattlePokemonStatus({
+      statusCondition: null,
+      specialAttackRank: 6,
+      specialDefenseRank: 6,
+    });
+    const defender = createBattlePokemonStatus({ id: 2 });
+    const ctx = createBattleContext();
+
+    const result = await effect.onUse(attacker, defender, ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/moves/effects/take-heart-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/take-heart-effect.ts
@@ -1,0 +1,52 @@
+import { IMoveEffect } from '../move-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../abilities/battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * 「ブレイブチャージ」の特殊効果実装
+ *
+ * 効果:
+ *  - 自分の状態異常を回復する
+ *  - 自分の特攻と特防をそれぞれ1段階上昇させる
+ *
+ * 状態異常回復・能力上昇は独立して試行される（片方が無効でももう片方は実行）
+ */
+export class TakeHeartEffect implements IMoveEffect {
+  async onUse(
+    attacker: BattlePokemonStatus,
+    _defender: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): Promise<string | null> {
+    if (!battleContext.battleRepository) {
+      return null;
+    }
+
+    const messages: string[] = [];
+    const updateData: Partial<BattlePokemonStatus> = {};
+
+    if (attacker.statusCondition && attacker.statusCondition !== StatusCondition.None) {
+      (updateData as Record<string, unknown>).statusCondition = StatusCondition.None;
+      messages.push('user was cured of its status condition!');
+    }
+
+    const newSpecialAttackRank = Math.min(6, attacker.specialAttackRank + 1);
+    const newSpecialDefenseRank = Math.min(6, attacker.specialDefenseRank + 1);
+
+    if (newSpecialAttackRank !== attacker.specialAttackRank) {
+      (updateData as Record<string, number>).specialAttackRank = newSpecialAttackRank;
+      messages.push('Special Attack rose!');
+    }
+    if (newSpecialDefenseRank !== attacker.specialDefenseRank) {
+      (updateData as Record<string, number>).specialDefenseRank = newSpecialDefenseRank;
+      messages.push('Special Defense rose!');
+    }
+
+    if (messages.length === 0) {
+      return null;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(attacker.id, updateData);
+    return messages.join(' ');
+  }
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -202,6 +202,10 @@ import { TearfulLookEffect } from './effects/tearful-look-effect';
 import { BellyDrumEffect } from './effects/belly-drum-effect';
 import { PainSplitEffect } from './effects/pain-split-effect';
 import { MementoEffect } from './effects/memento-effect';
+import { PowerSwapEffect } from './effects/power-swap-effect';
+import { GuardSwapEffect } from './effects/guard-swap-effect';
+import { FilletAwayEffect } from './effects/fillet-away-effect';
+import { TakeHeartEffect } from './effects/take-heart-effect';
 
 /**
  * 技のレジストリ
@@ -465,6 +469,11 @@ export class MoveRegistry {
       this.registry.set('はらだいこ', new BellyDrumEffect());
       this.registry.set('いたみわけ', new PainSplitEffect());
       this.registry.set('おきみやげ', new MementoEffect());
+      // 変化カテゴリ「その他」: 能力交換/HP操作/ステ+治癒の複合系（Issue #103 一部）
+      this.registry.set('パワースワップ', new PowerSwapEffect());
+      this.registry.set('ガードスワップ', new GuardSwapEffect());
+      this.registry.set('みをけずる', new FilletAwayEffect());
+      this.registry.set('ブレイブチャージ', new TakeHeartEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #103 続編。**ランク交換 / HP 操作 / ステ+治癒 の複合系4件**を実装。

| 技 | 効果 |
|---|---|
| パワースワップ | 自分と相手の攻撃・特攻ランクを交換 |
| ガードスワップ | 自分と相手の防御・特防ランクを交換 |
| みをけずる | 最大 HP の 1/2 を支払い、攻撃・特攻・素早さを +2 |
| ブレイブチャージ | 自分の状態異常治癒 + 特攻・特防 +1（独立試行） |

### 設計メモ
- パワースワップ / ガードスワップ: 既存 `HeartSwapEffect`（全ランク交換）の部分版
- みをけずる: `BellyDrumEffect`（#103 part3）と同じ HP コスト機構、複数能力上昇
- ブレイブチャージ: 状態異常治癒と能力上昇は独立試行（片方が無効でももう片方は実行）

### 取り下げメモ
当初しょうりのまい/おかたづけ/ハバネロエキスも含める予定だったが、これらは PR #212 で追加した
`BaseSelfMultiStatChangeMoveEffect` / `BaseOpponentMultiStatChangeMoveEffect` に依存する。
#212 マージ後に別 PR で追加予定。

## Test plan
- [x] `power-swap-effect.spec.ts`: 3ケース（PowerSwap 交換 / 他能力非変更 / GuardSwap 交換）
- [x] `fillet-away-effect.spec.ts`: 3ケース（成功 / HP不足 / +6 既存）
- [x] `take-heart-effect.spec.ts`: 3ケース（状態異常治癒+能力上昇 / 状態異常無し / 全条件無効）
- [x] `npm test`: 122 suites / 700 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #103