### PR TITLE
feat: 変化カテゴリ「その他」小粒3件を追加 (Issue #103一部)

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/captivate-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/captivate-effect.ts
@@ -1,0 +1,14 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「ゆうわく」の特殊効果実装
+ *
+ * 効果: 相手の特攻を 2 段階下げる
+ * 注: 本家では「異性の相手のみ」の条件があるが、性別情報のモデリングが
+ *     未整備のため、本実装では性別を問わず適用する
+ */
+export class CaptivateEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'specialAttack';
+  protected readonly rankChange = -2;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/defog-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/defog-effect.ts
@@ -1,0 +1,14 @@
+import { BaseOpponentStatChangeMoveEffect } from './base/base-opponent-stat-change-move-effect';
+import { StatType } from './base/base-stat-change-effect';
+
+/**
+ * 「きりばらい」の特殊効果実装
+ *
+ * 効果: 相手の回避ランクを 1 段階下げる
+ * 注: 相手側のフィールド効果（リフレクター・ひかりのかべ・しんぴのまもり等）の解除は
+ *     現状の engine には対応するフックがなく、別処理として扱う（フィールド state 拡張が必要）
+ */
+export class DefogEffect extends BaseOpponentStatChangeMoveEffect {
+  protected readonly statType: StatType = 'evasion';
+  protected readonly rankChange = -1;
+}

--- a/server/src/modules/pokemon/domain/moves/effects/snowscape-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/snowscape-effect.ts
@@ -1,0 +1,12 @@
+import { BaseWeatherMoveEffect } from './base/base-weather-move-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * 「ゆきげしき」の特殊効果実装
+ *
+ * 効果: 天候を「あられ」にする（本家では「ゆき」だが engine の Weather enum に Snow が無いため Hail で代用）
+ */
+export class SnowscapeEffect extends BaseWeatherMoveEffect {
+  protected readonly weather = Weather.Hail;
+  protected readonly message = 'It started to snow!';
+}

--- a/server/src/modules/pokemon/domain/moves/move-registry.ts
+++ b/server/src/modules/pokemon/domain/moves/move-registry.ts
@@ -206,6 +206,9 @@ import { PowerSwapEffect } from './effects/power-swap-effect';
 import { GuardSwapEffect } from './effects/guard-swap-effect';
 import { FilletAwayEffect } from './effects/fillet-away-effect';
 import { TakeHeartEffect } from './effects/take-heart-effect';
+import { DefogEffect } from './effects/defog-effect';
+import { CaptivateEffect } from './effects/captivate-effect';
+import { SnowscapeEffect } from './effects/snowscape-effect';
 
 /**
  * 技のレジストリ
@@ -474,6 +477,10 @@ export class MoveRegistry {
       this.registry.set('ガードスワップ', new GuardSwapEffect());
       this.registry.set('みをけずる', new FilletAwayEffect());
       this.registry.set('ブレイブチャージ', new TakeHeartEffect());
+      // 変化カテゴリ「その他」: 小粒（Issue #103 一部）
+      this.registry.set('きりばらい', new DefogEffect());
+      this.registry.set('ゆうわく', new CaptivateEffect());
+      this.registry.set('ゆきげしき', new SnowscapeEffect());
     } catch (error) {
       throw new Error(
         `Failed to initialize MoveRegistry: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
Issue #103 続編。既存 base のみで実装可能な小粒3件を追加。

| 技 | 効果 |
|---|---|
| きりばらい | 相手の回避 -1（`BaseOpponentStatChangeMoveEffect`） |
| ゆうわく | 相手の特攻 -2（`BaseOpponentStatChangeMoveEffect`） |
| ゆきげしき | 天候を Hail に変更（`BaseWeatherMoveEffect`） |

### 設計メモ
- きりばらい: 「相手フィールドのリフレクター等を解除」は engine 未整備で別処理。回避 -1 のみ実装
- ゆうわく: 「異性のみ」条件は性別モデリングが engine 未整備のため無条件適用
- ゆきげしき: 本家「ゆき」だが engine の `Weather` enum に `Snow` が無いため `Hail` で代用

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 個別 spec は #93 系の前例に従い割愛（既存 base のテストで網羅）。

Refs #103