### PR TITLE
feat: 天候依存 HP 回復特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -19,6 +19,8 @@ import { ShinryokuEffect } from './effects/damage-modify/shinryoku-effect';
 import { MoukaEffect } from './effects/damage-modify/mouka-effect';
 import { GekiryuuEffect } from './effects/damage-modify/gekiryuu-effect';
 import { DrizzleEffect } from './effects/weather/drizzle-effect';
+import { RainDishEffect } from './effects/weather/rain-dish-effect';
+import { IceBodyEffect } from './effects/weather/ice-body-effect';
 import { DroughtEffect } from './effects/weather/drought-effect';
 import { SandStreamEffect } from './effects/weather/sand-stream-effect';
 import { SnowWarningEffect } from './effects/weather/snow-warning-effect';
@@ -101,6 +103,9 @@ export class AbilityRegistry {
       this.registry.set('ひでり', new DroughtEffect());
       this.registry.set('すなあらし', new SandStreamEffect());
       this.registry.set('ゆきふらし', new SnowWarningEffect());
+      // 天候依存の HP 回復特性（Issue #84 一部）
+      this.registry.set('あめうけざら', new RainDishEffect());
+      this.registry.set('アイスボディ', new IceBodyEffect());
       // でんきエンジン: でんきタイプの技を無効化し、素早さを上げる特性
       this.registry.set('でんきエンジン', new MotorDriveEffect());
       // フィールドカテゴリの特性（フィールド展開）

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-heal-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-heal-effect.spec.ts
@@ -1,0 +1,122 @@
+import { BaseWeatherHealEffect } from './base-weather-heal-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '@/modules/pokemon/domain/abilities/battle-context.interface';
+import { Battle, BattleStatus, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestRainHeal extends BaseWeatherHealEffect {
+  protected readonly weather = Weather.Rain;
+}
+
+class TestHailHeal extends BaseWeatherHealEffect {
+  protected readonly weather = Weather.Hail;
+}
+
+describe('BaseWeatherHealEffect', () => {
+  const createBattlePokemonStatus = (
+    overrides?: Partial<BattlePokemonStatus>,
+  ): BattlePokemonStatus =>
+    new BattlePokemonStatus(
+      overrides?.id ?? 1,
+      overrides?.battleId ?? 1,
+      overrides?.trainedPokemonId ?? 1,
+      overrides?.trainerId ?? 1,
+      overrides?.isActive ?? true,
+      overrides?.currentHp ?? 50,
+      overrides?.maxHp ?? 160, // 160 / 16 = 10
+      overrides?.attackRank ?? 0,
+      overrides?.defenseRank ?? 0,
+      overrides?.specialAttackRank ?? 0,
+      overrides?.specialDefenseRank ?? 0,
+      overrides?.speedRank ?? 0,
+      overrides?.accuracyRank ?? 0,
+      overrides?.evasionRank ?? 0,
+      overrides?.statusCondition ?? null,
+    );
+
+  const createBattleContext = (weather: Weather | null): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, weather, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('対象天候のとき maxHp/16 を回復する', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 50, maxHp: 160 });
+    const ctx = createBattleContext(Weather.Rain);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      currentHp: 60,
+    });
+  });
+
+  it('対象外の天候では回復しない', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 50 });
+    const ctx = createBattleContext(Weather.Sun);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('天候が null の場合は回復しない', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 50 });
+    const ctx = createBattleContext(null);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('HP 満タンなら回復しない', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 160, maxHp: 160 });
+    const ctx = createBattleContext(Weather.Rain);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('maxHp を超えないようクランプ', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 155, maxHp: 160 });
+    const ctx = createBattleContext(Weather.Rain);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      currentHp: 160,
+    });
+  });
+
+  it('Hail-heal 派生クラスはあられで動作', async () => {
+    const effect = new TestHailHeal();
+    const pokemon = createBattlePokemonStatus({ currentHp: 50, maxHp: 160 });
+    const ctx = createBattleContext(Weather.Hail);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      currentHp: 60,
+    });
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const effect = new TestRainHeal();
+    const pokemon = createBattlePokemonStatus();
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, Weather.Rain, null, BattleStatus.Active, null),
+    };
+
+    await expect(effect.onTurnEnd(pokemon, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-heal-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-heal-effect.ts
@@ -1,0 +1,49 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * 天候依存の HP 回復特性の基底クラス
+ *
+ * 例: あめうけざら（雨で 1/16 回復）、アイスボディ（あられで 1/16 回復）
+ *
+ * 各派生クラスは対象天候のみを指定すれば良い
+ */
+export abstract class BaseWeatherHealEffect implements IAbilityEffect {
+  /**
+   * 回復が発動する天候
+   */
+  protected abstract readonly weather: Weather;
+
+  /**
+   * 回復率（既定は 1/16）
+   */
+  protected readonly healRatio: number = 1 / 16;
+
+  async onTurnEnd(pokemon: BattlePokemonStatus, battleContext?: BattleContext): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (battleContext.battle.weather !== this.weather) {
+      return;
+    }
+
+    // HP 満タンなら回復しない
+    if (pokemon.currentHp >= pokemon.maxHp) {
+      return;
+    }
+
+    const healAmount = Math.max(1, Math.floor(pokemon.maxHp * this.healRatio));
+    const newHp = Math.min(pokemon.maxHp, pokemon.currentHp + healAmount);
+
+    if (newHp === pokemon.currentHp) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      currentHp: newHp,
+    });
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/weather/ice-body-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/weather/ice-body-effect.ts
@@ -1,0 +1,10 @@
+import { BaseWeatherHealEffect } from '../base/base-weather-heal-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * アイスボディ（Ice Body）特性の効果
+ * あられの間、ターン終了時に最大 HP の 1/16 を回復する
+ */
+export class IceBodyEffect extends BaseWeatherHealEffect {
+  protected readonly weather = Weather.Hail;
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/weather/rain-dish-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/weather/rain-dish-effect.ts
@@ -1,0 +1,10 @@
+import { BaseWeatherHealEffect } from '../base/base-weather-heal-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * あめうけざら（Rain Dish）特性の効果
+ * 雨の間、ターン終了時に最大 HP の 1/16 を回復する
+ */
+export class RainDishEffect extends BaseWeatherHealEffect {
+  protected readonly weather = Weather.Rain;
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」のうち、ターン終了時の天候依存 HP 回復タイプ **2件**を実装。直近の流れは技 (#103) だったが、技側で実装可能な簡易ロジックを概ね消化したため、特性側（#84）にも着手。

| 特性 | 効果 |
|---|---|
| あめうけざら (Rain Dish) | 雨の間、ターン終了時に最大 HP の 1/16 回復 |
| アイスボディ (Ice Body) | あられの間、ターン終了時に最大 HP の 1/16 回復 |

### 設計メモ
- 共通ロジック（天候チェック + maxHp/16 回復 + 上限クランプ）を `BaseWeatherHealEffect` として抽出
- 派生クラスは対象天候のみ指定（`Weather.Rain` / `Weather.Hail`）
- `healRatio` は派生クラスで上書き可能（将来 `サンパワー` 等の派生に対応）

## Test plan
- [x] `base-weather-heal-effect.spec.ts` 追加: 7ケース（対象天候/対象外天候/天候null/HP満タン/maxHpクランプ/Hail派生/リポジトリ無し）
- [x] `npm test`: 120 suites / 698 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84