### PR TITLE
feat: そうしょく特性を追加 (Issue #84一部、1件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -8,6 +8,7 @@ import { LevitateEffect } from './effects/immunity/levitate-effect';
 import { VoltAbsorbEffect } from './effects/immunity/volt-absorb-effect';
 import { FlashFireEffect } from './effects/immunity/flash-fire-effect';
 import { WaterAbsorbEffect } from './effects/immunity/water-absorb-effect';
+import { SapSipperEffect } from './effects/immunity/sap-sipper-effect';
 import { ObliviousEffect } from './effects/oblivious-effect';
 import { MultiscaleEffect } from './effects/damage-modify/multiscale-effect';
 import { GutsEffect } from './effects/stat-change/guts-effect';
@@ -113,6 +114,8 @@ export class AbilityRegistry {
       this.registry.set('ミストメイカー', new MistySurgeEffect());
       this.registry.set('グラスメイカー', new GrassySurgeEffect());
       this.registry.set('ちょすい', new WaterAbsorbEffect());
+      // そうしょく: くさ無効 + 攻撃 +1（Issue #84 一部、Motor Drive と同パターン）
+      this.registry.set('そうしょく', new SapSipperEffect());
       this.registry.set('はがねつかい', new SteelworkerEffect());
       this.registry.set('てきおうりょく', new AdaptabilityEffect());
       this.registry.set('ようりょくそ', new ChlorophyllEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/sap-sipper-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/sap-sipper-effect.spec.ts
@@ -1,0 +1,111 @@
+import { SapSipperEffect } from './sap-sipper-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Weather, Field, BattleStatus, Battle } from '@/modules/battle/domain/entities/battle.entity';
+import { IBattleRepository } from '@/modules/battle/domain/battle.repository.interface';
+
+describe('SapSipperEffect', () => {
+  let effect: SapSipperEffect;
+  let pokemon: BattlePokemonStatus;
+  let battleContext: BattleContext;
+  let mockBattleRepository: jest.Mocked<IBattleRepository>;
+
+  beforeEach(() => {
+    effect = new SapSipperEffect();
+    pokemon = new BattlePokemonStatus(
+      1,
+      1,
+      1,
+      1,
+      true,
+      100,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      null,
+    );
+
+    mockBattleRepository = {
+      update: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+      findBattlePokemonStatusByBattleId: jest.fn(),
+      createBattlePokemonStatus: jest.fn(),
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(pokemon),
+      findActivePokemonByBattleIdAndTrainerId: jest.fn(),
+      findBattlePokemonStatusById: jest.fn().mockResolvedValue(pokemon),
+      findBattlePokemonMovesByBattlePokemonStatusId: jest.fn(),
+      createBattlePokemonMove: jest.fn(),
+      updateBattlePokemonMove: jest.fn(),
+      findBattlePokemonMoveById: jest.fn(),
+    } as jest.Mocked<IBattleRepository>;
+
+    battleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, Weather.None, Field.None, BattleStatus.Active, null),
+      battleRepository: mockBattleRepository,
+    };
+  });
+
+  describe('isImmuneToType', () => {
+    it('くさタイプの技に対して true を返す', () => {
+      expect(effect.isImmuneToType(pokemon, 'くさ', battleContext)).toBe(true);
+    });
+
+    it('くさタイプ以外の技に対して false を返す', () => {
+      expect(effect.isImmuneToType(pokemon, 'みず', battleContext)).toBe(false);
+      expect(effect.isImmuneToType(pokemon, 'ほのお', battleContext)).toBe(false);
+    });
+  });
+
+  describe('onAfterTakingDamage', () => {
+    it('くさ技を受けて無効化したとき、攻撃を +1 にする', async () => {
+      battleContext.moveTypeName = 'くさ';
+
+      await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+      expect(mockBattleRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+        attackRank: 1,
+      });
+    });
+
+    it('くさ以外の技では発動しない', async () => {
+      battleContext.moveTypeName = 'みず';
+
+      await effect.onAfterTakingDamage(pokemon, 50, battleContext);
+
+      expect(mockBattleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('moveTypeName が無いときは発動しない', async () => {
+      await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+      expect(mockBattleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('既に攻撃ランクが +6 のときは更新しない', async () => {
+      battleContext.moveTypeName = 'くさ';
+      const maxRankPokemon = new BattlePokemonStatus(
+        1, 1, 1, 1, true, 100, 100, 6, 0, 0, 0, 0, 0, 0, null,
+      );
+      mockBattleRepository.findBattlePokemonStatusById.mockResolvedValue(maxRankPokemon);
+
+      await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+      expect(mockBattleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+    });
+
+    it('battleRepository が無い場合は何もしない', async () => {
+      const ctx: BattleContext = {
+        battle: battleContext.battle,
+      };
+      ctx.moveTypeName = 'くさ';
+
+      await expect(effect.onAfterTakingDamage(pokemon, 0, ctx)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/sap-sipper-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/sap-sipper-effect.ts
@@ -1,0 +1,48 @@
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { BaseTypeImmunityEffect } from '../base/base-type-immunity-effect';
+
+/**
+ * そうしょく（Sap Sipper）特性の効果
+ * くさタイプの技を無効化し、その技を受けて無効化したときに攻撃を1段階上げる
+ *
+ * 既存の MotorDriveEffect（でんき無効 + 素早さ +1）と同パターン
+ */
+export class SapSipperEffect extends BaseTypeImmunityEffect {
+  protected readonly immuneTypes = ['くさ'] as const;
+
+  async onAfterTakingDamage(
+    pokemon: BattlePokemonStatus,
+    _originalDamage: number,
+    battleContext?: BattleContext,
+  ): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (!battleContext.moveTypeName) {
+      return;
+    }
+
+    const isImmune = this.isImmuneToType(pokemon, battleContext.moveTypeName, battleContext);
+    if (!isImmune) {
+      return;
+    }
+
+    const currentStatus = await battleContext.battleRepository.findBattlePokemonStatusById(
+      pokemon.id,
+    );
+    if (!currentStatus) {
+      return;
+    }
+
+    const newAttackRank = Math.max(-6, Math.min(6, currentStatus.attackRank + 1));
+    if (newAttackRank === currentStatus.attackRank) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      attackRank: newAttackRank,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」のうち、Motor Drive と同パターンの「タイプ無効化 + 能力上昇」を実装。

| 特性 | 効果 |
|---|---|
| そうしょく (Sap Sipper) | くさタイプの技を無効化し、被弾時に攻撃を1段階上げる |

### 設計メモ
- 既存 `MotorDriveEffect`（でんき無効化 + 素早さ +1）と完全に同パターン
- `BaseTypeImmunityEffect` を継承し、`onAfterTakingDamage` で攻撃 +1
- ファイル配置は `immunity/` ディレクトリ（type-immunity 系統と整合。MotorDrive は `weather/` 配下にあるが、それは既存の配置揺らぎ）

## Test plan
- [x] `sap-sipper-effect.spec.ts` 追加: 7ケース（isImmuneToType くさ/非くさ、onAfterTakingDamage くさ発動/非くさスキップ/moveType無し/上限/リポジトリ無し）
- [x] `npm test`: 120 suites / 698 tests Pass（再実行で安定、`エアスラッシュ` の flake は既存問題）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84