### PR TITLE
feat: 天候/フィールド依存 SPE 2倍特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -3,6 +3,8 @@ import { IntimidateEffect } from './effects/stat-change/intimidate-effect';
 import { SwiftSwimEffect } from './effects/stat-change/swift-swim-effect';
 import { ChlorophyllEffect } from './effects/stat-change/chlorophyll-effect';
 import { SandRushEffect } from './effects/stat-change/sand-rush-effect';
+import { SlushRushEffect } from './effects/stat-change/slush-rush-effect';
+import { SurgeSurferEffect } from './effects/stat-change/surge-surfer-effect';
 import { InsomniaEffect } from './effects/immunity/insomnia-effect';
 import { LevitateEffect } from './effects/immunity/levitate-effect';
 import { VoltAbsorbEffect } from './effects/immunity/volt-absorb-effect';
@@ -120,6 +122,9 @@ export class AbilityRegistry {
       this.registry.set('てきおうりょく', new AdaptabilityEffect());
       this.registry.set('ようりょくそ', new ChlorophyllEffect());
       this.registry.set('すなかき', new SandRushEffect());
+      // 天候/フィールド依存 SPE2倍特性（Issue #84 一部、ようりょくそ・すいすい・すなかきと同パターン）
+      this.registry.set('ゆきがき', new SlushRushEffect());
+      this.registry.set('サーフテール', new SurgeSurferEffect());
       this.registry.set('こんじょう', new GutsHpThresholdEffect());
       this.registry.set('しんりょく', new ShinryokuEffect());
       this.registry.set('もうか', new MoukaEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-field-dependent-speed-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-field-dependent-speed-effect.spec.ts
@@ -1,0 +1,62 @@
+import { BaseFieldDependentSpeedEffect } from './base-field-dependent-speed-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestElectricTerrainSpeed extends BaseFieldDependentSpeedEffect {
+  protected readonly requiredFields = [Field.ElectricTerrain] as const;
+  protected readonly speedMultiplier = 2.0;
+}
+
+class TestMistyTerrainSpeed extends BaseFieldDependentSpeedEffect {
+  protected readonly requiredFields = [Field.MistyTerrain] as const;
+  protected readonly speedMultiplier = 1.5;
+}
+
+describe('BaseFieldDependentSpeedEffect', () => {
+  const createPokemon = (): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (field: Field | null): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, Weather.None, field, BattleStatus.Active, null),
+  });
+
+  it('対象フィールドのとき速度倍率を適用する', () => {
+    const effect = new TestElectricTerrainSpeed();
+    const pokemon = createPokemon();
+    const ctx = createCtx(Field.ElectricTerrain);
+
+    expect(effect.modifySpeed(pokemon, 100, ctx)).toBe(200);
+  });
+
+  it('対象外のフィールドでは undefined を返す', () => {
+    const effect = new TestElectricTerrainSpeed();
+    const pokemon = createPokemon();
+    const ctx = createCtx(Field.GrassyTerrain);
+
+    expect(effect.modifySpeed(pokemon, 100, ctx)).toBeUndefined();
+  });
+
+  it('フィールド null では undefined を返す', () => {
+    const effect = new TestElectricTerrainSpeed();
+    const pokemon = createPokemon();
+    const ctx = createCtx(null);
+
+    expect(effect.modifySpeed(pokemon, 100, ctx)).toBeUndefined();
+  });
+
+  it('battleContext が無い場合は undefined', () => {
+    const effect = new TestElectricTerrainSpeed();
+    const pokemon = createPokemon();
+
+    expect(effect.modifySpeed(pokemon, 100, undefined)).toBeUndefined();
+  });
+
+  it('1.5倍など整数で割り切れない倍率は Math.floor で切り捨て', () => {
+    const effect = new TestMistyTerrainSpeed();
+    const pokemon = createPokemon();
+    const ctx = createCtx(Field.MistyTerrain);
+
+    expect(effect.modifySpeed(pokemon, 99, ctx)).toBe(148); // 99 * 1.5 = 148.5 → 148
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-field-dependent-speed-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-field-dependent-speed-effect.ts
@@ -1,0 +1,46 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Field } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * フィールド依存の速度修正の基底クラス
+ * 特定のフィールドの時に速度を修正する汎用的な実装
+ *
+ * 各特性は、このクラスを継承してフィールドと倍率を設定するだけで実装できる
+ *
+ * 例: サーフテール（エレキフィールドで素早さ2倍）
+ */
+export abstract class BaseFieldDependentSpeedEffect implements IAbilityEffect {
+  /**
+   * 効果が発動するフィールドの配列
+   */
+  protected abstract readonly requiredFields: readonly Field[];
+
+  /**
+   * 速度倍率（1.0が通常、2.0が2倍など）
+   */
+  protected abstract readonly speedMultiplier: number;
+
+  modifySpeed(
+    _pokemon: BattlePokemonStatus,
+    speed: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (!battleContext) {
+      return undefined;
+    }
+
+    // フィールドを取得（battleContext.field が優先、なければ battle.field を使用）
+    const field = battleContext.field ?? battleContext.battle?.field ?? null;
+    if (!field) {
+      return undefined;
+    }
+
+    if (this.requiredFields.includes(field)) {
+      return Math.floor(speed * this.speedMultiplier);
+    }
+
+    return undefined;
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/slush-rush-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/slush-rush-effect.ts
@@ -1,0 +1,11 @@
+import { BaseWeatherDependentSpeedEffect } from '../base/base-weather-dependent-speed-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * ゆきがき（Slush Rush）特性の効果
+ * あられの時、素早さ2倍
+ */
+export class SlushRushEffect extends BaseWeatherDependentSpeedEffect {
+  protected readonly requiredWeathers = [Weather.Hail] as const;
+  protected readonly speedMultiplier = 2.0;
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/surge-surfer-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/surge-surfer-effect.ts
@@ -1,0 +1,11 @@
+import { BaseFieldDependentSpeedEffect } from '../base/base-field-dependent-speed-effect';
+import { Field } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * サーフテール（Surge Surfer）特性の効果
+ * エレキフィールドの時、素早さ2倍
+ */
+export class SurgeSurferEffect extends BaseFieldDependentSpeedEffect {
+  protected readonly requiredFields = [Field.ElectricTerrain] as const;
+  protected readonly speedMultiplier = 2.0;
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。既存「ようりょくそ・すいすい・すなかき」と同じ「条件下で素早さ2倍」パターン。

| 特性 | 効果 | 条件 |
|---|---|---|
| ゆきがき (Slush Rush) | 素早さ 2倍 | あられ天候 |
| サーフテール (Surge Surfer) | 素早さ 2倍 | エレキフィールド |

### 設計メモ
- ゆきがき: 既存 `BaseWeatherDependentSpeedEffect` を流用、`requiredWeathers = [Weather.Hail]`
- サーフテール: 新規 `BaseFieldDependentSpeedEffect` を追加（既存の天候版と同形）
  - 派生クラスは `requiredFields` と `speedMultiplier` を指定するだけ

## Test plan
- [x] `base-field-dependent-speed-effect.spec.ts` 追加: 5ケース（対象/対象外/null/未指定/小数倍率）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84