### PR TITLE
feat: タイプ無効化+特攻+1特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -11,6 +11,8 @@ import { VoltAbsorbEffect } from './effects/immunity/volt-absorb-effect';
 import { FlashFireEffect } from './effects/immunity/flash-fire-effect';
 import { WaterAbsorbEffect } from './effects/immunity/water-absorb-effect';
 import { SapSipperEffect } from './effects/immunity/sap-sipper-effect';
+import { LightningRodEffect } from './effects/immunity/lightning-rod-effect';
+import { StormDrainEffect } from './effects/immunity/storm-drain-effect';
 import { ObliviousEffect } from './effects/oblivious-effect';
 import { MultiscaleEffect } from './effects/damage-modify/multiscale-effect';
 import { GutsEffect } from './effects/stat-change/guts-effect';
@@ -118,6 +120,9 @@ export class AbilityRegistry {
       this.registry.set('ちょすい', new WaterAbsorbEffect());
       // そうしょく: くさ無効 + 攻撃 +1（Issue #84 一部、Motor Drive と同パターン）
       this.registry.set('そうしょく', new SapSipperEffect());
+      // タイプ無効化 + 特攻 +1（Issue #84 一部）
+      this.registry.set('ひらいしん', new LightningRodEffect());
+      this.registry.set('よびみず', new StormDrainEffect());
       this.registry.set('はがねつかい', new SteelworkerEffect());
       this.registry.set('てきおうりょく', new AdaptabilityEffect());
       this.registry.set('ようりょくそ', new ChlorophyllEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-type-immunity-with-stat-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-type-immunity-with-stat-boost-effect.spec.ts
@@ -1,0 +1,97 @@
+import { BaseTypeImmunityWithStatBoostEffect } from './base-type-immunity-with-stat-boost-effect';
+import { StatType } from './base-stat-boost-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Weather, Field, BattleStatus, Battle } from '@/modules/battle/domain/entities/battle.entity';
+import { IBattleRepository } from '@/modules/battle/domain/battle.repository.interface';
+
+class TestLightningRodLike extends BaseTypeImmunityWithStatBoostEffect {
+  protected readonly immuneTypes = ['でんき'] as const;
+  protected readonly boostStat: StatType = 'specialAttack';
+}
+
+class TestSpeedBoostLike extends BaseTypeImmunityWithStatBoostEffect {
+  protected readonly immuneTypes = ['みず'] as const;
+  protected readonly boostStat: StatType = 'speed';
+}
+
+describe('BaseTypeImmunityWithStatBoostEffect', () => {
+  let pokemon: BattlePokemonStatus;
+  let battleContext: BattleContext;
+  let mockBattleRepository: jest.Mocked<IBattleRepository>;
+
+  beforeEach(() => {
+    pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+    mockBattleRepository = {
+      update: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+      findBattlePokemonStatusByBattleId: jest.fn(),
+      createBattlePokemonStatus: jest.fn(),
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(pokemon),
+      findActivePokemonByBattleIdAndTrainerId: jest.fn(),
+      findBattlePokemonStatusById: jest.fn().mockResolvedValue(pokemon),
+      findBattlePokemonMovesByBattlePokemonStatusId: jest.fn(),
+      createBattlePokemonMove: jest.fn(),
+      updateBattlePokemonMove: jest.fn(),
+      findBattlePokemonMoveById: jest.fn(),
+    } as jest.Mocked<IBattleRepository>;
+
+    battleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, Weather.None, Field.None, BattleStatus.Active, null),
+      battleRepository: mockBattleRepository,
+    };
+  });
+
+  it('Lightning Rod 相当: でんき技を無効化して特攻 +1', async () => {
+    const effect = new TestLightningRodLike();
+    battleContext.moveTypeName = 'でんき';
+
+    await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+    expect(mockBattleRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      specialAttackRank: 1,
+    });
+  });
+
+  it('対象外タイプでは発動しない', async () => {
+    const effect = new TestLightningRodLike();
+    battleContext.moveTypeName = 'ほのお';
+
+    await effect.onAfterTakingDamage(pokemon, 50, battleContext);
+
+    expect(mockBattleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('別の boostStat を持つ派生クラスはそのステを上げる', async () => {
+    const effect = new TestSpeedBoostLike();
+    battleContext.moveTypeName = 'みず';
+
+    await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+    expect(mockBattleRepository.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      speedRank: 1,
+    });
+  });
+
+  it('能力ランクが既に +6 のときは更新しない', async () => {
+    const effect = new TestLightningRodLike();
+    battleContext.moveTypeName = 'でんき';
+    const maxRankPokemon = new BattlePokemonStatus(
+      1, 1, 1, 1, true, 100, 100, 0, 0, 6, 0, 0, 0, 0, null,
+    );
+    mockBattleRepository.findBattlePokemonStatusById.mockResolvedValue(maxRankPokemon);
+
+    await effect.onAfterTakingDamage(pokemon, 0, battleContext);
+
+    expect(mockBattleRepository.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const effect = new TestLightningRodLike();
+    const ctx: BattleContext = { battle: battleContext.battle, moveTypeName: 'でんき' };
+
+    await expect(effect.onAfterTakingDamage(pokemon, 0, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-type-immunity-with-stat-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-type-immunity-with-stat-boost-effect.ts
@@ -1,0 +1,75 @@
+import { BaseTypeImmunityEffect } from './base-type-immunity-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatType } from './base-stat-boost-effect';
+
+/**
+ * タイプ無効化 + 能力ランク上昇の基底クラス
+ *
+ * 例:
+ *  - ひらいしん（Lightning Rod）: でんき無効化 + 特攻 +1
+ *  - よびみず（Storm Drain）: みず無効化 + 特攻 +1
+ *  - そうしょく（Sap Sipper）: くさ無効化 + 攻撃 +1（既存実装）
+ *  - でんきエンジン（Motor Drive）: でんき無効化 + 素早さ +1（既存実装）
+ *
+ * 既存の `MotorDriveEffect` / `SapSipperEffect` は本 base を使用していないが、
+ * 新規追加分は本 base 経由で実装することでロジック重複を避ける。
+ */
+export abstract class BaseTypeImmunityWithStatBoostEffect extends BaseTypeImmunityEffect {
+  /**
+   * 上昇させるステータスの種類
+   */
+  protected abstract readonly boostStat: StatType;
+
+  /**
+   * 上昇させるランク量（既定は +1）
+   */
+  protected readonly rankIncrease: number = 1;
+
+  private static readonly statRankPropMap: Record<StatType, keyof BattlePokemonStatus> = {
+    attack: 'attackRank',
+    defense: 'defenseRank',
+    specialAttack: 'specialAttackRank',
+    specialDefense: 'specialDefenseRank',
+    speed: 'speedRank',
+    accuracy: 'accuracyRank',
+    evasion: 'evasionRank',
+  };
+
+  async onAfterTakingDamage(
+    pokemon: BattlePokemonStatus,
+    _originalDamage: number,
+    battleContext?: BattleContext,
+  ): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (!battleContext.moveTypeName) {
+      return;
+    }
+
+    const isImmune = this.isImmuneToType(pokemon, battleContext.moveTypeName, battleContext);
+    if (!isImmune) {
+      return;
+    }
+
+    const currentStatus = await battleContext.battleRepository.findBattlePokemonStatusById(
+      pokemon.id,
+    );
+    if (!currentStatus) {
+      return;
+    }
+
+    const propName = BaseTypeImmunityWithStatBoostEffect.statRankPropMap[this.boostStat];
+    const currentRank = currentStatus[propName] as number;
+    const newRank = Math.max(-6, Math.min(6, currentRank + this.rankIncrease));
+    if (newRank === currentRank) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      [propName]: newRank,
+    } as Partial<BattlePokemonStatus>);
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/lightning-rod-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/lightning-rod-effect.ts
@@ -1,0 +1,11 @@
+import { BaseTypeImmunityWithStatBoostEffect } from '../base/base-type-immunity-with-stat-boost-effect';
+import { StatType } from '../base/base-stat-boost-effect';
+
+/**
+ * ひらいしん（Lightning Rod）特性の効果
+ * でんきタイプの技を無効化し、特攻を1段階上げる
+ */
+export class LightningRodEffect extends BaseTypeImmunityWithStatBoostEffect {
+  protected readonly immuneTypes = ['でんき'] as const;
+  protected readonly boostStat: StatType = 'specialAttack';
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/storm-drain-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/storm-drain-effect.ts
@@ -1,0 +1,11 @@
+import { BaseTypeImmunityWithStatBoostEffect } from '../base/base-type-immunity-with-stat-boost-effect';
+import { StatType } from '../base/base-stat-boost-effect';
+
+/**
+ * よびみず（Storm Drain）特性の効果
+ * みずタイプの技を無効化し、特攻を1段階上げる
+ */
+export class StormDrainEffect extends BaseTypeImmunityWithStatBoostEffect {
+  protected readonly immuneTypes = ['みず'] as const;
+  protected readonly boostStat: StatType = 'specialAttack';
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。「特定タイプを無効化 + 特攻 +1」パターン。

| 特性 | 効果 |
|---|---|
| ひらいしん (Lightning Rod) | でんきタイプの技を無効化 + 特攻 +1 |
| よびみず (Storm Drain) | みずタイプの技を無効化 + 特攻 +1 |

### 設計メモ
- 既存の `MotorDriveEffect`（でんき免疫+SPE+1）と `SapSipperEffect`（くさ免疫+ATK+1）は、互いに同じ「タイプ免疫+ステランク+1」パターンながら個別実装になっていた
- 新規 `BaseTypeImmunityWithStatBoostEffect` を追加し、`immuneTypes` / `boostStat` / `rankIncrease` の3項目だけで派生できる構造に整理
- ひらいしん・よびみずは本 base 経由で実装（共に SPA +1）
- 既存の `MotorDriveEffect` / `SapSipperEffect` は本 PR では触らず、別 PR で `BaseTypeImmunityWithStatBoostEffect` に統合する余地を残す

## Test plan
- [x] `base-type-immunity-with-stat-boost-effect.spec.ts` 追加: 5ケース（Lightning Rod相当/対象外/別ステ派生/+6既存/リポジトリ無し）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84