### PR TITLE
feat: ターン終了時の自己状態異常治癒特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -13,6 +13,8 @@ import { WaterAbsorbEffect } from './effects/immunity/water-absorb-effect';
 import { SapSipperEffect } from './effects/immunity/sap-sipper-effect';
 import { LightningRodEffect } from './effects/immunity/lightning-rod-effect';
 import { StormDrainEffect } from './effects/immunity/storm-drain-effect';
+import { HydrationEffect } from './effects/immunity/hydration-effect';
+import { ShedSkinEffect } from './effects/immunity/shed-skin-effect';
 import { ObliviousEffect } from './effects/oblivious-effect';
 import { MultiscaleEffect } from './effects/damage-modify/multiscale-effect';
 import { GutsEffect } from './effects/stat-change/guts-effect';
@@ -145,6 +147,9 @@ export class AbilityRegistry {
       this.registry.set('みずのベール', new WaterVeilEffect());
       this.registry.set('やるき', new VitalSpiritEffect());
       this.registry.set('すいほう', new WaterBubbleEffect());
+      // ターン終了時の自己状態異常治癒（Issue #84 一部）
+      this.registry.set('うるおいボディ', new HydrationEffect());
+      this.registry.set('だっぴ', new ShedSkinEffect());
       // その他カテゴリの特性
       this.registry.set('ふくがん', new CompoundEyesEffect());
       this.registry.set('せいしんりょく', new InnerFocusEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-turn-end-self-status-cure-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-turn-end-self-status-cure-effect.spec.ts
@@ -1,0 +1,85 @@
+import { BaseTurnEndSelfStatusCureEffect } from './base-turn-end-self-status-cure-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestAlwaysCure extends BaseTurnEndSelfStatusCureEffect {
+  protected shouldCure(): boolean {
+    return true;
+  }
+}
+
+class TestNeverCure extends BaseTurnEndSelfStatusCureEffect {
+  protected shouldCure(): boolean {
+    return false;
+  }
+}
+
+describe('BaseTurnEndSelfStatusCureEffect', () => {
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, Weather.None, Field.None, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('shouldCure が true で状態異常があるなら治癒する', async () => {
+    const effect = new TestAlwaysCure();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it('shouldCure が false なら治癒しない', async () => {
+    const effect = new TestNeverCure();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('状態異常が無いなら治癒しない', async () => {
+    const effect = new TestAlwaysCure();
+    const pokemon = createPokemon(null);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('statusCondition が None でも治癒しない', async () => {
+    const effect = new TestAlwaysCure();
+    const pokemon = createPokemon(StatusCondition.None);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const effect = new TestAlwaysCure();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    await expect(effect.onTurnEnd(pokemon, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-turn-end-self-status-cure-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-turn-end-self-status-cure-effect.ts
@@ -1,0 +1,41 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * ターン終了時に条件付きで自分の状態異常を治す特性の基底クラス
+ *
+ * 例:
+ *  - うるおいボディ（Hydration）: 雨の間、ターン終了時に状態異常治癒
+ *  - だっぴ（Shed Skin）: 30%の確率でターン終了時に状態異常治癒
+ *
+ * 派生クラスは `shouldCure` を override して発動条件を指定する
+ */
+export abstract class BaseTurnEndSelfStatusCureEffect implements IAbilityEffect {
+  /**
+   * 治癒を発動するかどうかを判定
+   */
+  protected abstract shouldCure(
+    pokemon: BattlePokemonStatus,
+    battleContext: BattleContext,
+  ): boolean;
+
+  async onTurnEnd(pokemon: BattlePokemonStatus, battleContext?: BattleContext): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (!pokemon.statusCondition || pokemon.statusCondition === StatusCondition.None) {
+      return;
+    }
+
+    if (!this.shouldCure(pokemon, battleContext)) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/hydration-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/hydration-effect.spec.ts
@@ -1,0 +1,53 @@
+import { HydrationEffect } from './hydration-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('HydrationEffect', () => {
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (weather: Weather | null): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, weather, Field.None, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  it('雨で状態異常があるなら治癒する', async () => {
+    const effect = new HydrationEffect();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx(Weather.Rain);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it('雨以外では治癒しない', async () => {
+    const effect = new HydrationEffect();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx(Weather.Sun);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('天候 null では治癒しない', async () => {
+    const effect = new HydrationEffect();
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx(null);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/hydration-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/hydration-effect.ts
@@ -1,0 +1,14 @@
+import { BaseTurnEndSelfStatusCureEffect } from '../base/base-turn-end-self-status-cure-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * うるおいボディ（Hydration）特性の効果
+ * 雨の間、ターン終了時に自分の状態異常を治す
+ */
+export class HydrationEffect extends BaseTurnEndSelfStatusCureEffect {
+  protected shouldCure(_pokemon: BattlePokemonStatus, battleContext: BattleContext): boolean {
+    return battleContext.battle?.weather === Weather.Rain;
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/shed-skin-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/shed-skin-effect.spec.ts
@@ -1,0 +1,60 @@
+import { ShedSkinEffect } from './shed-skin-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('ShedSkinEffect', () => {
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, Weather.None, Field.None, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('30% 内（0.0〜0.3）で当選すると治癒する', async () => {
+    const effect = new ShedSkinEffect();
+    const pokemon = createPokemon(StatusCondition.Paralysis);
+    const ctx = createCtx();
+    jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it('確率外では治癒しない', async () => {
+    const effect = new ShedSkinEffect();
+    const pokemon = createPokemon(StatusCondition.Paralysis);
+    const ctx = createCtx();
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('状態異常が無いなら治癒しない', async () => {
+    const effect = new ShedSkinEffect();
+    const pokemon = createPokemon(null);
+    const ctx = createCtx();
+    jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/shed-skin-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/shed-skin-effect.ts
@@ -1,0 +1,15 @@
+import { BaseTurnEndSelfStatusCureEffect } from '../base/base-turn-end-self-status-cure-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * だっぴ（Shed Skin）特性の効果
+ * ターン終了時に 30% の確率で自分の状態異常を治す
+ */
+export class ShedSkinEffect extends BaseTurnEndSelfStatusCureEffect {
+  private static readonly CURE_CHANCE = 0.3;
+
+  protected shouldCure(_pokemon: BattlePokemonStatus, _battleContext: BattleContext): boolean {
+    return Math.random() < ShedSkinEffect.CURE_CHANCE;
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。「ターン終了時に条件付きで自己状態異常を治癒」パターン。

| 特性 | 効果 |
|---|---|
| うるおいボディ (Hydration) | 雨の間、ターン終了時に自分の状態異常を治癒 |
| だっぴ (Shed Skin) | 30% の確率でターン終了時に自分の状態異常を治癒 |

### 設計メモ
- 共通ロジック（ターン終了 + 状態異常存在チェック + 治癒）を `BaseTurnEndSelfStatusCureEffect` として抽出
- 派生クラスは `shouldCure(pokemon, ctx): boolean` を override して発動条件のみ指定
  - うるおいボディ: 雨判定
  - だっぴ: 30% 確率判定

## Test plan
- [x] `base-turn-end-self-status-cure-effect.spec.ts` 追加: 5ケース（true/false 派生、状態異常無し、None、リポジトリ無し）
- [x] `hydration-effect.spec.ts` 追加: 3ケース（雨で治癒、雨以外スキップ、天候 null）
- [x] `shed-skin-effect.spec.ts` 追加: 3ケース（確率内/確率外/状態異常無し）
- [x] `npm test`: 122 suites / 702 tests Pass（再実行で安定、`エアスラッシュ` の確率 flake は既存問題）
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84