### PR TITLE
feat: むしのしらせ特性を追加 (Issue #84一部、1件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -25,6 +25,7 @@ import { AdaptabilityEffect } from './effects/damage-modify/adaptability-effect'
 import { ShinryokuEffect } from './effects/damage-modify/shinryoku-effect';
 import { MoukaEffect } from './effects/damage-modify/mouka-effect';
 import { GekiryuuEffect } from './effects/damage-modify/gekiryuu-effect';
+import { SwarmEffect } from './effects/damage-modify/swarm-effect';
 import { DrizzleEffect } from './effects/weather/drizzle-effect';
 import { RainDishEffect } from './effects/weather/rain-dish-effect';
 import { IceBodyEffect } from './effects/weather/ice-body-effect';
@@ -136,6 +137,8 @@ export class AbilityRegistry {
       this.registry.set('しんりょく', new ShinryokuEffect());
       this.registry.set('もうか', new MoukaEffect());
       this.registry.set('げきりゅう', new GekiryuuEffect());
+      // むしのしらせ: HP 1/3 以下でむし技 1.5 倍（しんりょく/もうか/げきりゅうと同パターン、Issue #84 一部）
+      this.registry.set('むしのしらせ', new SwarmEffect());
       this.registry.set('いとあみ', new StickyWebEffect());
       this.registry.set('どくどく', new PoisonPointEffect());
       this.registry.set('せいでんき', new StaticEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/swarm-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/swarm-effect.spec.ts
@@ -1,0 +1,55 @@
+import { SwarmEffect } from './swarm-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('SwarmEffect', () => {
+  let effect: SwarmEffect;
+
+  beforeEach(() => {
+    effect = new SwarmEffect();
+  });
+
+  const createPokemon = (currentHp: number, maxHp: number = 100): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, currentHp, maxHp, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (moveTypeName?: string): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveTypeName,
+  });
+
+  it('HP が 1/3 以下かつ むしタイプの技なら 1.5 倍する', () => {
+    const pokemon = createPokemon(30, 100);
+    const ctx = createCtx('むし');
+
+    expect(effect.modifyDamageDealt(pokemon, 100, ctx)).toBe(150);
+  });
+
+  it('HP が 1/3 より上なら修正しない', () => {
+    const pokemon = createPokemon(50, 100);
+    const ctx = createCtx('むし');
+
+    expect(effect.modifyDamageDealt(pokemon, 100, ctx)).toBeUndefined();
+  });
+
+  it('HP が低くても むし以外の技は修正しない', () => {
+    const pokemon = createPokemon(30, 100);
+    const ctx = createCtx('くさ');
+
+    expect(effect.modifyDamageDealt(pokemon, 100, ctx)).toBeUndefined();
+  });
+
+  it('moveTypeName が無いなら修正しない', () => {
+    const pokemon = createPokemon(30, 100);
+    const ctx = createCtx();
+
+    expect(effect.modifyDamageDealt(pokemon, 100, ctx)).toBeUndefined();
+  });
+
+  it('1.5 倍で小数になる値は Math.floor で切り捨て', () => {
+    const pokemon = createPokemon(30, 100);
+    const ctx = createCtx('むし');
+
+    expect(effect.modifyDamageDealt(pokemon, 99, ctx)).toBe(148); // 99 * 1.5 = 148.5 → 148
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/swarm-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/swarm-effect.ts
@@ -1,0 +1,35 @@
+import { BaseHpThresholdEffect } from '../base/base-hp-threshold-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * むしのしらせ（Swarm）特性の効果
+ * HP が 1/3 以下のとき、むしタイプの技の威力を 1.5 倍にする
+ *
+ * 既存の `ShinryokuEffect`（くさ）/ `MoukaEffect`（ほのお）/ `GekiryuuEffect`（みず）と同パターン
+ */
+export class SwarmEffect extends BaseHpThresholdEffect {
+  protected readonly thresholdType = 'third' as const;
+  protected readonly affectedType = 'むし';
+  protected readonly damageMultiplier = 1.5;
+
+  modifyDamageDealt(
+    pokemon: BattlePokemonStatus,
+    damage: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (!this.checkHpThreshold(pokemon)) {
+      return undefined;
+    }
+
+    if (!battleContext?.moveTypeName) {
+      return undefined;
+    }
+
+    if (battleContext.moveTypeName === this.affectedType) {
+      return Math.floor(damage * this.damageMultiplier);
+    }
+
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **1件**を実装。御三家系列の「ピンチタイプブースト」パターンの未実装版。

| 特性 | 効果 |
|---|---|
| むしのしらせ (Swarm) | HP 1/3 以下のとき、むしタイプの技の威力を 1.5 倍 |

### 設計メモ
- 既存 `ShinryokuEffect`（くさ）/ `MoukaEffect`（ほのお）/ `GekiryuuEffect`（みず）と完全に同パターン
- `BaseHpThresholdEffect` を継承、`thresholdType = 'third'`、`affectedType = 'むし'`

## Test plan
- [x] `swarm-effect.spec.ts`: 5ケース（HP+タイプ一致/HP高/タイプ違い/moveType無し/小数切り捨て）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84