### PR TITLE
feat: リーフガード特性を追加 (Issue #84一部、1件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -15,6 +15,7 @@ import { LightningRodEffect } from './effects/immunity/lightning-rod-effect';
 import { StormDrainEffect } from './effects/immunity/storm-drain-effect';
 import { HydrationEffect } from './effects/immunity/hydration-effect';
 import { ShedSkinEffect } from './effects/immunity/shed-skin-effect';
+import { LeafGuardEffect } from './effects/immunity/leaf-guard-effect';
 import { ObliviousEffect } from './effects/oblivious-effect';
 import { MultiscaleEffect } from './effects/damage-modify/multiscale-effect';
 import { GutsEffect } from './effects/stat-change/guts-effect';
@@ -153,6 +154,8 @@ export class AbilityRegistry {
       // ターン終了時の自己状態異常治癒（Issue #84 一部）
       this.registry.set('うるおいボディ', new HydrationEffect());
       this.registry.set('だっぴ', new ShedSkinEffect());
+      // リーフガード: 晴天時に全主要状態異常を無効化（Issue #84 一部）
+      this.registry.set('リーフガード', new LeafGuardEffect());
       // その他カテゴリの特性
       this.registry.set('ふくがん', new CompoundEyesEffect());
       this.registry.set('せいしんりょく', new InnerFocusEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/leaf-guard-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/leaf-guard-effect.spec.ts
@@ -1,0 +1,63 @@
+import { LeafGuardEffect } from './leaf-guard-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('LeafGuardEffect', () => {
+  const createPokemon = (): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (weather: Weather | null): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, weather, Field.None, BattleStatus.Active, null),
+  });
+
+  let effect: LeafGuardEffect;
+
+  beforeEach(() => {
+    effect = new LeafGuardEffect();
+  });
+
+  it.each([
+    ['Burn', StatusCondition.Burn],
+    ['Paralysis', StatusCondition.Paralysis],
+    ['Poison', StatusCondition.Poison],
+    ['BadPoison', StatusCondition.BadPoison],
+    ['Sleep', StatusCondition.Sleep],
+    ['Freeze', StatusCondition.Freeze],
+  ])('晴天で %s を無効化（false 返却）', (_label, status) => {
+    expect(effect.canReceiveStatusCondition(createPokemon(), status, createCtx(Weather.Sun))).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ['Flinch', StatusCondition.Flinch],
+    ['Confusion', StatusCondition.Confusion],
+  ])('晴天でも %s は無効化対象外（undefined 返却）', (_label, status) => {
+    expect(
+      effect.canReceiveStatusCondition(createPokemon(), status, createCtx(Weather.Sun)),
+    ).toBeUndefined();
+  });
+
+  it('晴天でない場合は undefined（判定しない）', () => {
+    expect(
+      effect.canReceiveStatusCondition(createPokemon(), StatusCondition.Burn, createCtx(Weather.Rain)),
+    ).toBeUndefined();
+    expect(
+      effect.canReceiveStatusCondition(createPokemon(), StatusCondition.Burn, createCtx(null)),
+    ).toBeUndefined();
+  });
+
+  it('battleContext が無い場合は undefined', () => {
+    expect(
+      effect.canReceiveStatusCondition(createPokemon(), StatusCondition.Burn, undefined),
+    ).toBeUndefined();
+  });
+
+  it('battleContext.weather（オーバーライド）が優先される', () => {
+    const ctx = createCtx(Weather.Rain);
+    ctx.weather = Weather.Sun;
+    expect(effect.canReceiveStatusCondition(createPokemon(), StatusCondition.Burn, ctx)).toBe(false);
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/immunity/leaf-guard-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/immunity/leaf-guard-effect.ts
@@ -1,0 +1,40 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * リーフガード（Leaf Guard）特性の効果
+ * 晴れの間、すべての主要状態異常（やけど・まひ・どく・もうどく・ねむり・こおり）を無効化する
+ *
+ * 既存の単一状態異常を無効化する特性（みずのベール等）と異なり、天候条件付きで全状態を無効化
+ */
+export class LeafGuardEffect implements IAbilityEffect {
+  private static readonly IMMUNE_STATUS_CONDITIONS: ReadonlySet<StatusCondition> = new Set([
+    StatusCondition.Burn,
+    StatusCondition.Paralysis,
+    StatusCondition.Poison,
+    StatusCondition.BadPoison,
+    StatusCondition.Sleep,
+    StatusCondition.Freeze,
+  ]);
+
+  canReceiveStatusCondition(
+    _pokemon: BattlePokemonStatus,
+    statusCondition: StatusCondition,
+    battleContext?: BattleContext,
+  ): boolean | undefined {
+    if (!battleContext) {
+      return undefined;
+    }
+    const weather = battleContext.weather ?? battleContext.battle?.weather ?? null;
+    if (weather !== Weather.Sun) {
+      return undefined;
+    }
+    if (LeafGuardEffect.IMMUNE_STATUS_CONDITIONS.has(statusCondition)) {
+      return false;
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **1件**を実装。条件付き全状態異常無効化パターン。

| 特性 | 効果 |
|---|---|
| リーフガード (Leaf Guard) | 晴天の間、すべての主要状態異常（やけど/まひ/どく/もうどく/ねむり/こおり）を無効化 |

### 設計メモ
- 既存の単一状態異常無効化（みずのベール = 火傷免疫 等）と異なり、天候条件付きで複数状態を一括無効化
- `canReceiveStatusCondition` フックで `battleContext.weather === Weather.Sun` を判定
- 単一インターフェース実装のため独自クラス（既存 base には合致せず）。本家挙動に従い Confusion/Flinch は対象外

## Test plan
- [x] `leaf-guard-effect.spec.ts`: 11ケース（晴天で主要6状態を無効化 / 晴天でも Confusion/Flinch は対象外 / 晴天以外/null/ctx 無し / weather オーバーライド優先）
- [x] `npm test`: 120 suites / 702 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84