### PR TITLE
feat: 状態異常時ダメージブースト特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -27,6 +27,8 @@ import { ShinryokuEffect } from './effects/damage-modify/shinryoku-effect';
 import { MoukaEffect } from './effects/damage-modify/mouka-effect';
 import { GekiryuuEffect } from './effects/damage-modify/gekiryuu-effect';
 import { SwarmEffect } from './effects/damage-modify/swarm-effect';
+import { ToxicBoostEffect } from './effects/damage-modify/toxic-boost-effect';
+import { FlareBoostEffect } from './effects/damage-modify/flare-boost-effect';
 import { DrizzleEffect } from './effects/weather/drizzle-effect';
 import { RainDishEffect } from './effects/weather/rain-dish-effect';
 import { IceBodyEffect } from './effects/weather/ice-body-effect';
@@ -140,6 +142,9 @@ export class AbilityRegistry {
       this.registry.set('げきりゅう', new GekiryuuEffect());
       // むしのしらせ: HP 1/3 以下でむし技 1.5 倍（しんりょく/もうか/げきりゅうと同パターン、Issue #84 一部）
       this.registry.set('むしのしらせ', new SwarmEffect());
+      // 状態異常時にダメージ 1.5 倍する特性（Issue #84 一部）
+      this.registry.set('どくぼうそう', new ToxicBoostEffect());
+      this.registry.set('ねつぼうそう', new FlareBoostEffect());
       this.registry.set('いとあみ', new StickyWebEffect());
       this.registry.set('どくどく', new PoisonPointEffect());
       this.registry.set('せいでんき', new StaticEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/flare-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/flare-boost-effect.spec.ts
@@ -1,0 +1,41 @@
+import { FlareBoostEffect } from './flare-boost-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('FlareBoostEffect', () => {
+  let effect: FlareBoostEffect;
+
+  beforeEach(() => {
+    effect = new FlareBoostEffect();
+  });
+
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (cat?: 'Physical' | 'Special' | 'Status'): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveCategory: cat,
+  });
+
+  it('やけど × 特殊技なら 1.5 倍', () => {
+    const pokemon = createPokemon(StatusCondition.Burn);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Special'))).toBe(150);
+  });
+
+  it('やけどでも物理技は修正しない', () => {
+    const pokemon = createPokemon(StatusCondition.Burn);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Physical'))).toBeUndefined();
+  });
+
+  it('やけど以外の状態異常では修正しない', () => {
+    const pokemon = createPokemon(StatusCondition.Poison);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Special'))).toBeUndefined();
+  });
+
+  it('状態異常無しなら修正しない', () => {
+    const pokemon = createPokemon(null);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Special'))).toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/flare-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/flare-boost-effect.ts
@@ -1,0 +1,31 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * ねつぼうそう（Flare Boost）特性の効果
+ * やけど状態のとき、特殊技の威力を 1.5 倍にする
+ *
+ * 注: 本家挙動は「特攻ステータスが 1.5 倍」だが、ダメージ計算の最終段で同等の結果になるため
+ *     modifyDamageDealt で実装する
+ */
+export class FlareBoostEffect implements IAbilityEffect {
+  private static readonly DAMAGE_MULTIPLIER = 1.5;
+
+  modifyDamageDealt(
+    pokemon: BattlePokemonStatus,
+    damage: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (pokemon.statusCondition !== StatusCondition.Burn) {
+      return undefined;
+    }
+
+    if (battleContext?.moveCategory !== 'Special') {
+      return undefined;
+    }
+
+    return Math.floor(damage * FlareBoostEffect.DAMAGE_MULTIPLIER);
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/toxic-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/toxic-boost-effect.spec.ts
@@ -1,0 +1,51 @@
+import { ToxicBoostEffect } from './toxic-boost-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('ToxicBoostEffect', () => {
+  let effect: ToxicBoostEffect;
+
+  beforeEach(() => {
+    effect = new ToxicBoostEffect();
+  });
+
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (cat?: 'Physical' | 'Special' | 'Status'): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveCategory: cat,
+  });
+
+  it('どく状態 × 物理技なら 1.5 倍', () => {
+    const pokemon = createPokemon(StatusCondition.Poison);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Physical'))).toBe(150);
+  });
+
+  it('もうどく状態 × 物理技なら 1.5 倍', () => {
+    const pokemon = createPokemon(StatusCondition.BadPoison);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Physical'))).toBe(150);
+  });
+
+  it('物理技でも毒以外の状態異常では修正しない', () => {
+    const pokemon = createPokemon(StatusCondition.Burn);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Physical'))).toBeUndefined();
+  });
+
+  it('どく状態でも特殊技は修正しない', () => {
+    const pokemon = createPokemon(StatusCondition.Poison);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Special'))).toBeUndefined();
+  });
+
+  it('状態異常無しなら修正しない', () => {
+    const pokemon = createPokemon(null);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx('Physical'))).toBeUndefined();
+  });
+
+  it('moveCategory 無しなら修正しない', () => {
+    const pokemon = createPokemon(StatusCondition.Poison);
+    expect(effect.modifyDamageDealt(pokemon, 100, createCtx())).toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/toxic-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/toxic-boost-effect.ts
@@ -1,0 +1,34 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * どくぼうそう（Toxic Boost）特性の効果
+ * 毒/猛毒状態のとき、物理技の威力を 1.5 倍にする
+ *
+ * 注: 本家挙動は「攻撃ステータスが 1.5 倍」だが、ダメージ計算の最終段で同等の結果になるため
+ *     modifyDamageDealt で実装する
+ */
+export class ToxicBoostEffect implements IAbilityEffect {
+  private static readonly DAMAGE_MULTIPLIER = 1.5;
+
+  modifyDamageDealt(
+    pokemon: BattlePokemonStatus,
+    damage: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (
+      pokemon.statusCondition !== StatusCondition.Poison &&
+      pokemon.statusCondition !== StatusCondition.BadPoison
+    ) {
+      return undefined;
+    }
+
+    if (battleContext?.moveCategory !== 'Physical') {
+      return undefined;
+    }
+
+    return Math.floor(damage * ToxicBoostEffect.DAMAGE_MULTIPLIER);
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。「自分の状態異常をトリガーに同カテゴリ技の威力を 1.5 倍する」パターン。

| 特性 | 効果 |
|---|---|
| どくぼうそう (Toxic Boost) | 毒/猛毒状態のとき、物理技の威力 1.5 倍 |
| ねつぼうそう (Flare Boost) | やけど状態のとき、特殊技の威力 1.5 倍 |

### 設計メモ
- 本家挙動は「攻撃/特攻ステータスが 1.5 倍」だが、ダメージ計算の最終段で同等の結果になるため `modifyDamageDealt` で近似実装
- `battleContext.moveCategory` で技カテゴリ判定、`pokemon.statusCondition` で状態判定
- 状態が無い・状態違反・カテゴリ違反のいずれかで `undefined` を返し、修正をスキップ

## Test plan
- [x] `toxic-boost-effect.spec.ts`: 6ケース（毒×物理 / もうどく×物理 / やけど×物理スキップ / 毒×特殊スキップ / 状態無し / カテゴリ無し）
- [x] `flare-boost-effect.spec.ts`: 4ケース（やけど×特殊 / やけど×物理スキップ / 他状態スキップ / 状態無し）
- [x] `npm test`: 121 suites / 701 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84