### PR TITLE
feat: いたずらごころ・ノーガード特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -50,6 +50,8 @@ import { WaterVeilEffect } from './effects/immunity/water-veil-effect';
 import { VitalSpiritEffect } from './effects/immunity/vital-spirit-effect';
 import { WaterBubbleEffect } from './effects/immunity/water-bubble-effect';
 import { CompoundEyesEffect } from './effects/other/compound-eyes-effect';
+import { PranksterEffect } from './effects/other/prankster-effect';
+import { NoGuardEffect } from './effects/other/no-guard-effect';
 import { InnerFocusEffect } from './effects/other/inner-focus-effect';
 import { LimberEffect } from './effects/other/limber-effect';
 import { MagmaArmorEffect } from './effects/other/magma-armor-effect';
@@ -163,6 +165,9 @@ export class AbilityRegistry {
       this.registry.set('リーフガード', new LeafGuardEffect());
       // その他カテゴリの特性
       this.registry.set('ふくがん', new CompoundEyesEffect());
+      // 優先度+命中率系（Issue #84 一部）
+      this.registry.set('いたずらごころ', new PranksterEffect());
+      this.registry.set('ノーガード', new NoGuardEffect());
       this.registry.set('せいしんりょく', new InnerFocusEffect());
       this.registry.set('じゅうなん', new LimberEffect());
       this.registry.set('マグマのよろい', new MagmaArmorEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/other/no-guard-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/no-guard-effect.spec.ts
@@ -1,0 +1,32 @@
+import { NoGuardEffect } from './no-guard-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('NoGuardEffect', () => {
+  const pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const ctx: BattleContext = {
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+  };
+
+  let effect: NoGuardEffect;
+
+  beforeEach(() => {
+    effect = new NoGuardEffect();
+  });
+
+  it('命中率を 100 に上書きする', () => {
+    expect(effect.modifyAccuracy(pokemon, 50, ctx)).toBe(100);
+    expect(effect.modifyAccuracy(pokemon, 80, ctx)).toBe(100);
+    expect(effect.modifyAccuracy(pokemon, 100, ctx)).toBe(100);
+  });
+
+  it('元の命中率が 0 でも 100 を返す', () => {
+    expect(effect.modifyAccuracy(pokemon, 0, ctx)).toBe(100);
+  });
+
+  it('battleContext が無くても 100 を返す', () => {
+    expect(effect.modifyAccuracy(pokemon, 50, undefined)).toBe(100);
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/other/no-guard-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/no-guard-effect.ts
@@ -1,0 +1,23 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * ノーガード（No Guard）特性の効果
+ * 自分の技は必ず命中する（命中率を 100 に上書き）
+ *
+ * 注: 本家挙動では「相手の技も自分に必ず命中する」も含まれるが、
+ *     現状の engine には防御側から相手の命中率を上書きするフックが無い。
+ *     攻撃側の挙動のみを実装する（accuracy-calculator.ts:84 経由）。
+ */
+export class NoGuardEffect implements IAbilityEffect {
+  private static readonly FORCED_HIT_ACCURACY = 100;
+
+  modifyAccuracy(
+    _pokemon: BattlePokemonStatus,
+    _accuracy: number,
+    _battleContext?: BattleContext,
+  ): number | undefined {
+    return NoGuardEffect.FORCED_HIT_ACCURACY;
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/other/prankster-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/prankster-effect.spec.ts
@@ -1,0 +1,38 @@
+import { PranksterEffect } from './prankster-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('PranksterEffect', () => {
+  const pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (cat?: 'Physical' | 'Special' | 'Status'): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveCategory: cat,
+  });
+
+  let effect: PranksterEffect;
+
+  beforeEach(() => {
+    effect = new PranksterEffect();
+  });
+
+  it('変化技の優先度を +1 する', () => {
+    expect(effect.modifyPriority(pokemon, 0, createCtx('Status'))).toBe(1);
+    expect(effect.modifyPriority(pokemon, 5, createCtx('Status'))).toBe(6);
+    expect(effect.modifyPriority(pokemon, -1, createCtx('Status'))).toBe(0);
+  });
+
+  it('物理・特殊技は修正しない（undefined）', () => {
+    expect(effect.modifyPriority(pokemon, 0, createCtx('Physical'))).toBeUndefined();
+    expect(effect.modifyPriority(pokemon, 0, createCtx('Special'))).toBeUndefined();
+  });
+
+  it('moveCategory が無い場合は修正しない', () => {
+    expect(effect.modifyPriority(pokemon, 0, createCtx())).toBeUndefined();
+  });
+
+  it('battleContext が無い場合は修正しない', () => {
+    expect(effect.modifyPriority(pokemon, 0, undefined)).toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/other/prankster-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/prankster-effect.ts
@@ -1,0 +1,20 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * いたずらごころ（Prankster）特性の効果
+ * 変化技の優先度を +1 する
+ */
+export class PranksterEffect implements IAbilityEffect {
+  modifyPriority(
+    _pokemon: BattlePokemonStatus,
+    movePriority: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (battleContext?.moveCategory !== 'Status') {
+      return undefined;
+    }
+    return movePriority + 1;
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。優先度/命中率系の単純フック。

| 特性 | 効果 |
|---|---|
| いたずらごころ (Prankster) | 変化技の優先度を +1 |
| ノーガード (No Guard) | 自分の技は必ず命中（命中率を 100 に上書き） |

### 設計メモ
- **いたずらごころ**: `modifyPriority` フックで `moveCategory === 'Status'` のときのみ `+1`
- **ノーガード（攻撃側のみ）**: `modifyAccuracy` で 100 を返す
  - 本家挙動では「相手の技も自分に必ず命中する」も含まれるが、現状の engine には防御側から
    相手の命中率を上書きするフックが無いため攻撃側のみ実装
  - 防御側挙動の対応には accuracy-calculator に新フック（例 `forceAccuracyOnDefender`）の追加が必要

## Test plan
- [x] `prankster-effect.spec.ts`: 4ケース（Status +1 / 物理特殊スキップ / cat無し / ctx無し）
- [x] `no-guard-effect.spec.ts`: 3ケース（命中率上書き / 元0でも100 / ctx無し）
- [x] `npm test`: 121 suites / 698 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84