### PR TITLE
feat: 天候依存の回避率ブースト特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -5,6 +5,8 @@ import { ChlorophyllEffect } from './effects/stat-change/chlorophyll-effect';
 import { SandRushEffect } from './effects/stat-change/sand-rush-effect';
 import { SlushRushEffect } from './effects/stat-change/slush-rush-effect';
 import { SurgeSurferEffect } from './effects/stat-change/surge-surfer-effect';
+import { SandVeilEffect } from './effects/stat-change/sand-veil-effect';
+import { SnowCloakEffect } from './effects/stat-change/snow-cloak-effect';
 import { InsomniaEffect } from './effects/immunity/insomnia-effect';
 import { LevitateEffect } from './effects/immunity/levitate-effect';
 import { VoltAbsorbEffect } from './effects/immunity/volt-absorb-effect';
@@ -138,6 +140,9 @@ export class AbilityRegistry {
       // 天候/フィールド依存 SPE2倍特性（Issue #84 一部、ようりょくそ・すいすい・すなかきと同パターン）
       this.registry.set('ゆきがき', new SlushRushEffect());
       this.registry.set('サーフテール', new SurgeSurferEffect());
+      // 天候依存の回避率ブースト（Issue #84 一部）
+      this.registry.set('すながくれ', new SandVeilEffect());
+      this.registry.set('ゆきがくれ', new SnowCloakEffect());
       this.registry.set('こんじょう', new GutsHpThresholdEffect());
       this.registry.set('しんりょく', new ShinryokuEffect());
       this.registry.set('もうか', new MoukaEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-dependent-evasion-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-dependent-evasion-effect.spec.ts
@@ -1,0 +1,46 @@
+import { BaseWeatherDependentEvasionEffect } from './base-weather-dependent-evasion-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus, Field, Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+class TestSandVeil extends BaseWeatherDependentEvasionEffect {
+  protected readonly requiredWeather = Weather.Sandstorm;
+}
+
+class TestHailEvasion extends BaseWeatherDependentEvasionEffect {
+  protected readonly requiredWeather = Weather.Hail;
+}
+
+describe('BaseWeatherDependentEvasionEffect', () => {
+  const pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (weather: Weather | null): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, weather, Field.None, BattleStatus.Active, null),
+  });
+
+  it('対象天候のとき 0.2 を返す', () => {
+    const effect = new TestSandVeil();
+    expect(effect.modifyEvasion(pokemon, 100, createCtx(Weather.Sandstorm))).toBe(0.2);
+  });
+
+  it('対象外の天候では undefined', () => {
+    const effect = new TestSandVeil();
+    expect(effect.modifyEvasion(pokemon, 100, createCtx(Weather.Rain))).toBeUndefined();
+  });
+
+  it('天候 null では undefined', () => {
+    const effect = new TestSandVeil();
+    expect(effect.modifyEvasion(pokemon, 100, createCtx(null))).toBeUndefined();
+  });
+
+  it('battleContext が無い場合は undefined', () => {
+    const effect = new TestSandVeil();
+    expect(effect.modifyEvasion(pokemon, 100, undefined)).toBeUndefined();
+  });
+
+  it('Hail 派生クラスはあられで動作', () => {
+    const effect = new TestHailEvasion();
+    expect(effect.modifyEvasion(pokemon, 100, createCtx(Weather.Hail))).toBe(0.2);
+    expect(effect.modifyEvasion(pokemon, 100, createCtx(Weather.Sandstorm))).toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-dependent-evasion-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-weather-dependent-evasion-effect.ts
@@ -1,0 +1,42 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * 天候依存の回避率ブースト特性の基底クラス
+ *
+ * 例:
+ *  - すながくれ（Sand Veil）: すなあらしで回避率 +20%
+ *  - ゆきがくれ（Snow Cloak）: あられで回避率 +20%
+ *
+ * `modifyEvasion` は 0-1 の値を返し、`accuracy-calculator.ts` で
+ * `effectiveAccuracy * (1 - modifiedEvasion)` の形で適用される。
+ * 0.2 を返すと相手の命中率を 80% に減らす効果。
+ */
+export abstract class BaseWeatherDependentEvasionEffect implements IAbilityEffect {
+  /**
+   * 効果が発動する天候
+   */
+  protected abstract readonly requiredWeather: Weather;
+
+  /**
+   * 回避補正値（0-1、既定 0.2 = 相手の命中率 80%）
+   */
+  protected readonly evasionBoost: number = 0.2;
+
+  modifyEvasion(
+    _pokemon: BattlePokemonStatus,
+    _accuracy: number,
+    battleContext?: BattleContext,
+  ): number | undefined {
+    if (!battleContext) {
+      return undefined;
+    }
+    const weather = battleContext.weather ?? battleContext.battle?.weather ?? null;
+    if (weather !== this.requiredWeather) {
+      return undefined;
+    }
+    return this.evasionBoost;
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/sand-veil-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/sand-veil-effect.ts
@@ -1,0 +1,10 @@
+import { BaseWeatherDependentEvasionEffect } from '../base/base-weather-dependent-evasion-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * すながくれ（Sand Veil）特性の効果
+ * すなあらしの間、回避率 +20%（相手の命中率を 80% に減少）
+ */
+export class SandVeilEffect extends BaseWeatherDependentEvasionEffect {
+  protected readonly requiredWeather = Weather.Sandstorm;
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/snow-cloak-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/snow-cloak-effect.ts
@@ -1,0 +1,10 @@
+import { BaseWeatherDependentEvasionEffect } from '../base/base-weather-dependent-evasion-effect';
+import { Weather } from '@/modules/battle/domain/entities/battle.entity';
+
+/**
+ * ゆきがくれ（Snow Cloak）特性の効果
+ * あられの間、回避率 +20%（相手の命中率を 80% に減少）
+ */
+export class SnowCloakEffect extends BaseWeatherDependentEvasionEffect {
+  protected readonly requiredWeather = Weather.Hail;
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。modifyEvasion フックを使った天候依存の回避ブースト。

| 特性 | 効果 |
|---|---|
| すながくれ (Sand Veil) | すなあらしの間、回避率 +20%（相手の命中率 80%） |
| ゆきがくれ (Snow Cloak) | あられの間、回避率 +20%（相手の命中率 80%） |

### 設計メモ
- 共通ロジック（天候判定 + 0.2 回避補正）を `BaseWeatherDependentEvasionEffect` として抽出
- `modifyEvasion` は 0-1 の値を返し、`accuracy-calculator.ts` の `effectiveAccuracy * (1 - modifiedEvasion)` で適用される
- 派生クラスは `requiredWeather` のみ指定。`evasionBoost` は base のデフォルト（0.2）を使用、必要に応じて override 可能

## Test plan
- [x] `base-weather-dependent-evasion-effect.spec.ts`: 5ケース（対象天候/対象外/null/ctx無し/Hail派生）
- [x] `npm test`: 120 suites / 696 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84