### PR TITLE
feat: 場から下がるとき発動する特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -54,6 +54,8 @@ import { WaterBubbleEffect } from './effects/immunity/water-bubble-effect';
 import { CompoundEyesEffect } from './effects/other/compound-eyes-effect';
 import { PranksterEffect } from './effects/other/prankster-effect';
 import { NoGuardEffect } from './effects/other/no-guard-effect';
+import { NaturalCureEffect } from './effects/other/natural-cure-effect';
+import { RegeneratorEffect } from './effects/other/regenerator-effect';
 import { InnerFocusEffect } from './effects/other/inner-focus-effect';
 import { LimberEffect } from './effects/other/limber-effect';
 import { MagmaArmorEffect } from './effects/other/magma-armor-effect';
@@ -173,6 +175,9 @@ export class AbilityRegistry {
       // 優先度+命中率系（Issue #84 一部）
       this.registry.set('いたずらごころ', new PranksterEffect());
       this.registry.set('ノーガード', new NoGuardEffect());
+      // 場から下がるとき発動（Issue #84 一部）
+      this.registry.set('しぜんかいふく', new NaturalCureEffect());
+      this.registry.set('さいせいりょく', new RegeneratorEffect());
       this.registry.set('せいしんりょく', new InnerFocusEffect());
       this.registry.set('じゅうなん', new LimberEffect());
       this.registry.set('マグマのよろい', new MagmaArmorEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/other/natural-cure-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/natural-cure-effect.spec.ts
@@ -1,0 +1,65 @@
+import { NaturalCureEffect } from './natural-cure-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('NaturalCureEffect', () => {
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  let effect: NaturalCureEffect;
+
+  beforeEach(() => {
+    effect = new NaturalCureEffect();
+  });
+
+  it('状態異常があるなら治癒する', async () => {
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  });
+
+  it('状態異常 None なら何もしない', async () => {
+    const pokemon = createPokemon(StatusCondition.None);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('状態異常 null なら何もしない', async () => {
+    const pokemon = createPokemon(null);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const pokemon = createPokemon(StatusCondition.Burn);
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    await expect(effect.onSwitchOut(pokemon, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/other/natural-cure-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/natural-cure-effect.ts
@@ -1,0 +1,27 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * しぜんかいふく（Natural Cure）特性の効果
+ * 場から下がるとき、自分の状態異常を治す
+ */
+export class NaturalCureEffect implements IAbilityEffect {
+  async onSwitchOut(
+    pokemon: BattlePokemonStatus,
+    battleContext?: BattleContext,
+  ): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (!pokemon.statusCondition || pokemon.statusCondition === StatusCondition.None) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      statusCondition: StatusCondition.None,
+    });
+  }
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/other/regenerator-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/regenerator-effect.spec.ts
@@ -1,0 +1,66 @@
+import { RegeneratorEffect } from './regenerator-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('RegeneratorEffect', () => {
+  const createPokemon = (currentHp: number, maxHp: number = 150): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, currentHp, maxHp, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  let effect: RegeneratorEffect;
+
+  beforeEach(() => {
+    effect = new RegeneratorEffect();
+  });
+
+  it('最大HPの1/3を回復する', async () => {
+    const pokemon = createPokemon(50, 150);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      currentHp: 100, // 50 + (150/3 = 50)
+    });
+  });
+
+  it('HP 満タンなら回復しない', async () => {
+    const pokemon = createPokemon(150, 150);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('回復で maxHp を超えない', async () => {
+    const pokemon = createPokemon(140, 150);
+    const ctx = createCtx();
+
+    await effect.onSwitchOut(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      currentHp: 150,
+    });
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const pokemon = createPokemon(50, 150);
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    await expect(effect.onSwitchOut(pokemon, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/other/regenerator-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/regenerator-effect.ts
@@ -1,0 +1,35 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * さいせいりょく（Regenerator）特性の効果
+ * 場から下がるとき、最大 HP の 1/3 を回復する
+ */
+export class RegeneratorEffect implements IAbilityEffect {
+  private static readonly HEAL_RATIO = 1 / 3;
+
+  async onSwitchOut(
+    pokemon: BattlePokemonStatus,
+    battleContext?: BattleContext,
+  ): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    if (pokemon.currentHp >= pokemon.maxHp) {
+      return;
+    }
+
+    const healAmount = Math.max(1, Math.floor(pokemon.maxHp * RegeneratorEffect.HEAL_RATIO));
+    const newHp = Math.min(pokemon.maxHp, pokemon.currentHp + healAmount);
+
+    if (newHp === pokemon.currentHp) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      currentHp: newHp,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。`onSwitchOut` フックを活用する交代時発動系。

| 特性 | 効果 |
|---|---|
| しぜんかいふく (Natural Cure) | 場から下がるとき、自分の状態異常を治癒 |
| さいせいりょく (Regenerator) | 場から下がるとき、最大 HP の 1/3 を回復 |

### 設計メモ
- `pokemon-switcher.service.ts:53` で既に `onSwitchOut` フックが呼ばれており、engine 拡張なしで実装可能
- しぜんかいふく: 状態異常がある場合のみ `statusCondition = None` に更新
- さいせいりょく: 既に満タンの場合スキップ、`maxHp` でクランプ

## Test plan
- [x] `natural-cure-effect.spec.ts`: 4ケース（状態異常治癒 / None / null / リポジトリ無し）
- [x] `regenerator-effect.spec.ts`: 4ケース（HP/3回復 / 満タン / maxHpクランプ / リポジトリ無し）
- [x] `npm test`: 121 suites / 699 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84