### PR TITLE
feat: たいねつ・かそく特性を追加 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -23,6 +23,8 @@ import { MultiscaleEffect } from './effects/damage-modify/multiscale-effect';
 import { GutsEffect } from './effects/stat-change/guts-effect';
 import { GutsHpThresholdEffect } from './effects/stat-change/kongyou-effect';
 import { ThickFatEffect } from './effects/damage-modify/thick-fat-effect';
+import { HeatproofEffect } from './effects/damage-modify/heatproof-effect';
+import { SpeedBoostEffect } from './effects/stat-change/speed-boost-effect';
 import { SteelworkerEffect } from './effects/damage-modify/steelworker-effect';
 import { AdaptabilityEffect } from './effects/damage-modify/adaptability-effect';
 import { ShinryokuEffect } from './effects/damage-modify/shinryoku-effect';
@@ -114,6 +116,9 @@ export class AbilityRegistry {
       this.registry.set('ふゆう', new LevitateEffect());
       this.registry.set('すいすい', new SwiftSwimEffect());
       this.registry.set('あついしぼう', new ThickFatEffect());
+      // たいねつ / かそく（Issue #84 一部）
+      this.registry.set('たいねつ', new HeatproofEffect());
+      this.registry.set('かそく', new SpeedBoostEffect());
       this.registry.set('ちくでん', new VoltAbsorbEffect());
       this.registry.set('もらいび', new FlashFireEffect());
       this.registry.set('あめふらし', new DrizzleEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/heatproof-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/heatproof-effect.spec.ts
@@ -1,0 +1,36 @@
+import { HeatproofEffect } from './heatproof-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('HeatproofEffect', () => {
+  const pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  const createCtx = (moveTypeName?: string): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveTypeName,
+  });
+
+  let effect: HeatproofEffect;
+
+  beforeEach(() => {
+    effect = new HeatproofEffect();
+  });
+
+  it('ほのおタイプの技ダメージを半減する', () => {
+    expect(effect.modifyDamage(pokemon, 100, createCtx('ほのお'))).toBe(50);
+  });
+
+  it('ほのお以外のタイプは修正しない', () => {
+    expect(effect.modifyDamage(pokemon, 100, createCtx('みず'))).toBe(100);
+    expect(effect.modifyDamage(pokemon, 100, createCtx('こおり'))).toBe(100);
+  });
+
+  it('moveTypeName が無い場合は修正しない', () => {
+    expect(effect.modifyDamage(pokemon, 100, createCtx())).toBe(100);
+  });
+
+  it('小数になる値は Math.floor で切り捨て', () => {
+    expect(effect.modifyDamage(pokemon, 99, createCtx('ほのお'))).toBe(49); // 99 * 0.5 = 49.5 → 49
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/heatproof-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/heatproof-effect.ts
@@ -1,0 +1,13 @@
+import { BaseTypeDependentDamageEffect } from '../base/base-type-dependent-damage-effect';
+
+/**
+ * たいねつ（Heatproof）特性の効果
+ * ほのおタイプの技のダメージを半減する
+ *
+ * 注: 本家ではやけど状態の毎ターンダメージも半減するが、状態異常ダメージは
+ *     現状の engine では modifyDamage を経由しないため別処理として扱う
+ */
+export class HeatproofEffect extends BaseTypeDependentDamageEffect {
+  protected readonly affectedTypes = ['ほのお'] as const;
+  protected readonly damageMultiplier = 0.5;
+}

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/speed-boost-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/speed-boost-effect.spec.ts
@@ -1,0 +1,66 @@
+import { SpeedBoostEffect } from './speed-boost-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('SpeedBoostEffect', () => {
+  const createPokemon = (speedRank: number = 0): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, speedRank, 0, 0, null);
+
+  const createCtx = (): BattleContext => {
+    const battle = new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null);
+    const mockBattleRepository = {
+      updateBattlePokemonStatus: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      battle,
+      battleRepository: mockBattleRepository as unknown as BattleContext['battleRepository'],
+    };
+  };
+
+  let effect: SpeedBoostEffect;
+
+  beforeEach(() => {
+    effect = new SpeedBoostEffect();
+  });
+
+  it('ターン終了時に素早さランクを +1 する', async () => {
+    const pokemon = createPokemon(0);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      speedRank: 1,
+    });
+  });
+
+  it('既存ランクから +1（クランプ +6）', async () => {
+    const pokemon = createPokemon(5);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).toHaveBeenCalledWith(pokemon.id, {
+      speedRank: 6,
+    });
+  });
+
+  it('既に +6 なら更新しない', async () => {
+    const pokemon = createPokemon(6);
+    const ctx = createCtx();
+
+    await effect.onTurnEnd(pokemon, ctx);
+
+    expect(ctx.battleRepository?.updateBattlePokemonStatus).not.toHaveBeenCalled();
+  });
+
+  it('battleRepository が無い場合は何もしない', async () => {
+    const pokemon = createPokemon(0);
+    const ctx: BattleContext = {
+      battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    };
+
+    await expect(effect.onTurnEnd(pokemon, ctx)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/speed-boost-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/speed-boost-effect.ts
@@ -1,0 +1,27 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * かそく（Speed Boost）特性の効果
+ * ターン終了時に素早さランクを1段階上昇させる
+ */
+export class SpeedBoostEffect implements IAbilityEffect {
+  async onTurnEnd(
+    pokemon: BattlePokemonStatus,
+    battleContext?: BattleContext,
+  ): Promise<void> {
+    if (!battleContext?.battleRepository) {
+      return;
+    }
+
+    const newSpeedRank = Math.min(6, pokemon.speedRank + 1);
+    if (newSpeedRank === pokemon.speedRank) {
+      return;
+    }
+
+    await battleContext.battleRepository.updateBattlePokemonStatus(pokemon.id, {
+      speedRank: newSpeedRank,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を実装。

| 特性 | 効果 |
|---|---|
| たいねつ (Heatproof) | ほのおタイプの技ダメージを半減 |
| かそく (Speed Boost) | ターン終了時に素早さランクを +1 |

### 設計メモ
- **たいねつ**: 既存 `BaseTypeDependentDamageEffect`（あついしぼうと同 base）を継承、`affectedTypes = ['ほのお']`
  - 注: 本家ではやけど状態の毎ターンダメージも半減するが、状態異常ダメージは現状 `modifyDamage` を経由しないため別処理
- **かそく**: `onTurnEnd` フックで素早さランク +1（既存 `かちき`/`まけんき` のターン終了発動と同パターン）。+6 でクランプ

## Test plan
- [x] `heatproof-effect.spec.ts`: 4ケース（ほのお半減 / 他タイプ非修正 / type無し / 小数切り捨て）
- [x] `speed-boost-effect.spec.ts`: 4ケース（+1 / +6クランプ / 既存+6スキップ / リポジトリ無し）
- [x] `npm test`: 121 suites / 699 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84