### PR TITLE
feat: ヨガパワー特性を追加 (Issue #84一部、1件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -197,6 +197,8 @@ export class AbilityRegistry {
       this.registry.set('ちからずく', new SheerForceEffect());
       // ステータス変化カテゴリの特性
       this.registry.set('ちからもち', new HugePowerEffect());
+      // ヨガパワー: ちからもちと同効果（物理攻撃 2 倍）（Issue #84 一部）
+      this.registry.set('ヨガパワー', new HugePowerEffect());
       this.registry.set('はやあし', new QuickFeetEffect());
       this.registry.set('はとむね', new BigPecksEffect());
       this.registry.set('きもったま', new ScrappyEffect());


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **1件**をエイリアス追加。

| 特性 | 効果 |
|---|---|
| ヨガパワー (Pure Power) | 物理攻撃の威力を 2 倍にする（既存 `HugePowerEffect`（ちからもち）と同効果） |

### 設計メモ
- 本家ではちからもち（Huge Power）とヨガパワー（Pure Power）が完全に同じ効果なので、`HugePowerEffect` インスタンスを別名で再登録するだけのエイリアス実装
- 既存パターン（`あめをよぶ` / `あまごい` の Rain Dance 別表記、`はねる`/`おいわい`/`てをつなぐ` の NoOp 共有）と同じ手法

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: ロジック変更なし（既存 `HugePowerEffect` のテストで網羅）。

Refs #84