### PR TITLE
feat: ふしぎなウロコ特性を追加 (Issue #84一部、1件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -25,6 +25,7 @@ import { GutsHpThresholdEffect } from './effects/stat-change/kongyou-effect';
 import { ThickFatEffect } from './effects/damage-modify/thick-fat-effect';
 import { HeatproofEffect } from './effects/damage-modify/heatproof-effect';
 import { SpeedBoostEffect } from './effects/stat-change/speed-boost-effect';
+import { MarvelScaleEffect } from './effects/damage-modify/marvel-scale-effect';
 import { SteelworkerEffect } from './effects/damage-modify/steelworker-effect';
 import { AdaptabilityEffect } from './effects/damage-modify/adaptability-effect';
 import { ShinryokuEffect } from './effects/damage-modify/shinryoku-effect';
@@ -119,6 +120,8 @@ export class AbilityRegistry {
       // たいねつ / かそく（Issue #84 一部）
       this.registry.set('たいねつ', new HeatproofEffect());
       this.registry.set('かそく', new SpeedBoostEffect());
+      // ふしぎなウロコ: 状態異常時に物理ダメージ軽減（Issue #84 一部）
+      this.registry.set('ふしぎなウロコ', new MarvelScaleEffect());
       this.registry.set('ちくでん', new VoltAbsorbEffect());
       this.registry.set('もらいび', new FlashFireEffect());
       this.registry.set('あめふらし', new DrizzleEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/marvel-scale-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/marvel-scale-effect.spec.ts
@@ -1,0 +1,51 @@
+import { MarvelScaleEffect } from './marvel-scale-effect';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { Battle, BattleStatus } from '@/modules/battle/domain/entities/battle.entity';
+
+describe('MarvelScaleEffect', () => {
+  const createPokemon = (status: StatusCondition | null): BattlePokemonStatus =>
+    new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, status);
+
+  const createCtx = (cat?: 'Physical' | 'Special' | 'Status'): BattleContext => ({
+    battle: new Battle(1, 1, 2, 1, 2, 1, null, null, BattleStatus.Active, null),
+    moveCategory: cat,
+  });
+
+  let effect: MarvelScaleEffect;
+
+  beforeEach(() => {
+    effect = new MarvelScaleEffect();
+  });
+
+  it('状態異常時かつ物理技なら 1/1.5 倍に軽減', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Burn), 150, createCtx('Physical'))).toBe(100);
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Paralysis), 150, createCtx('Physical'))).toBe(100);
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Poison), 150, createCtx('Physical'))).toBe(100);
+  });
+
+  it('状態異常時でも特殊技は軽減しない', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Burn), 150, createCtx('Special'))).toBe(150);
+  });
+
+  it('状態異常無しなら軽減しない', () => {
+    expect(effect.modifyDamage(createPokemon(null), 150, createCtx('Physical'))).toBe(150);
+  });
+
+  it('状態異常 None なら軽減しない', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.None), 150, createCtx('Physical'))).toBe(150);
+  });
+
+  it('moveCategory が無い場合は軽減しない', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Burn), 150, createCtx())).toBe(150);
+  });
+
+  it('battleContext が無い場合は軽減しない', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Burn), 150, undefined)).toBe(150);
+  });
+
+  it('小数になる値は Math.floor で切り捨て', () => {
+    expect(effect.modifyDamage(createPokemon(StatusCondition.Burn), 100, createCtx('Physical'))).toBe(66); // 100/1.5 = 66.66 → 66
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/damage-modify/marvel-scale-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/damage-modify/marvel-scale-effect.ts
@@ -1,0 +1,29 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+import { StatusCondition } from '@/modules/battle/domain/entities/status-condition.enum';
+
+/**
+ * ふしぎなウロコ（Marvel Scale）特性の効果
+ * 状態異常のとき、防御ステータスを 1.5 倍にする
+ *
+ * 注: 本家挙動は「防御ステータス 1.5 倍」だが、ダメージ計算の最終段で
+ *     物理ダメージを 1/1.5 倍に軽減することで同等の結果になる
+ */
+export class MarvelScaleEffect implements IAbilityEffect {
+  private static readonly DEFENSE_BOOST = 1.5;
+
+  modifyDamage(
+    pokemon: BattlePokemonStatus,
+    damage: number,
+    battleContext?: BattleContext,
+  ): number {
+    if (!pokemon.statusCondition || pokemon.statusCondition === StatusCondition.None) {
+      return damage;
+    }
+    if (battleContext?.moveCategory !== 'Physical') {
+      return damage;
+    }
+    return Math.floor(damage / MarvelScaleEffect.DEFENSE_BOOST);
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **1件**を実装。

| 特性 | 効果 |
|---|---|
| ふしぎなウロコ (Marvel Scale) | 状態異常のとき、物理ダメージを 1/1.5 倍に軽減 |

### 設計メモ
- 本家挙動は「防御ステータスが 1.5 倍」だが、ダメージ計算の最終段で物理ダメージを 1/1.5 倍に軽減することで同等の結果になる
- `modifyDamage` フックで、`pokemon.statusCondition` が None 以外 かつ `moveCategory === 'Physical'` のとき `damage / 1.5` を返す
- どくぼうそう・ねつぼうそうの逆方向の発想（攻撃側で 1.5 倍 → 防御側で 1/1.5 倍）

## Test plan
- [x] `marvel-scale-effect.spec.ts`: 7ケース（やけど/まひ/どく × 物理軽減 / 特殊スキップ / 状態無し/None / カテゴリ無し / ctx無し / 小数切り捨て）
- [x] `npm test`: 120 suites / 698 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84