### PR TITLE
test: AirSlash 確率テストの flake を解消

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/base-status-condition-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base-status-condition-effect.spec.ts
@@ -153,25 +153,48 @@ describe('BaseStatusConditionEffect', () => {
       );
     });
 
-    it('エアスラッシュは30%の確率でひるみを付与する', async () => {
-      const effect = new AirSlashEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
+    describe('エアスラッシュ（30%でひるみ）', () => {
+      // 元の確率テスト（100回試行で 20-40 件期待）は ~3% の確率で flake していたため、
+      // Math.random を決定的にモックする形に置き換える
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 100; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
+      it('Math.random < 0.3 ならひるみを付与する', async () => {
+        const effect = new AirSlashEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 30%の確率なので、20%以上40%以下になることが期待される
-      expect(successCount).toBeGreaterThan(20);
-      expect(successCount).toBeLessThan(40);
+        expect(result).toBe('flinched!');
+      });
+
+      it('Math.random >= 0.3 ならひるみを付与しない', async () => {
+        const effect = new AirSlashEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
+
+      it('境界値: Math.random === 0.3 ならひるみを付与しない（chance < 1.0 のとき >= で判定）', async () => {
+        const effect = new AirSlashEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.3);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
直近のサイクルで複数回観測されていた既存テストの flake を解消。

### 問題
`BaseStatusConditionEffect.spec.ts` の `エアスラッシュは30%の確率でひるみを付与する` は、`Math.random()` を 100 回呼び出し、ひるみ付与の成功カウントが `20 < count < 40` を満たすことで「30% の確率」を検証していた。

しかし二項分布 B(100, 0.3) の理論計算では、`count <= 20` の確率が約 1.7%、`count >= 40` の確率が約 1.7% で、合計 **~3.4% の確率で flake** する。実際これまでの作業中、本テストが偶発的に失敗するケースが複数回観測された。

### 修正
`Math.random` を `jest.spyOn` で決定的にモックし、確率分岐の各経路を直接検証する形に置き換え:
- `< 0.3` でひるみ付与
- `>= 0.3` でスキップ
- 境界値（`=== 0.3`）の挙動（`if (this.chance < 1.0 && Math.random() >= this.chance)` で境界はスキップ側）

決定的テストになったため flake が原理的に発生しなくなる。

## Test plan
- [x] `npx jest base-status-condition-effect` を 3 回連続で実行して全 Pass を確認
- [x] `npm test`: 119 suites / 693 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 私が現在オープン中の 43 件の PR は本変更を取り込んでいないが、各 PR では再実行で安定することを確認済み。本 PR がマージされれば以降の PR は安定する。