### PR TITLE
feat: クリアボディ・ホワイトスモーク特性を登録 (Issue #84一部、2件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -73,6 +73,7 @@ import { SheerForceEffect } from './effects/damage-modify/sheer-force-effect';
 import { HugePowerEffect } from './effects/stat-change/huge-power-effect';
 import { QuickFeetEffect } from './effects/stat-change/quick-feet-effect';
 import { BigPecksEffect } from './effects/stat-change/big-pecks-effect';
+import { ClearBodyEffect } from './effects/stat-change/clear-body-effect';
 import { ScrappyEffect } from './effects/stat-change/scrappy-effect';
 import { DefiantEffect } from './effects/stat-change/defiant-effect';
 import { CompetitiveEffect } from './effects/stat-change/competitive-effect';
@@ -204,6 +205,10 @@ export class AbilityRegistry {
       this.registry.set('ヨガパワー', new HugePowerEffect());
       this.registry.set('はやあし', new QuickFeetEffect());
       this.registry.set('はとむね', new BigPecksEffect());
+      // クリアボディ / ホワイトスモーク: 能力ランク低下無効化マーカー（Issue #84 一部、BigPecks と同パターン）
+      const clearBody = new ClearBodyEffect();
+      this.registry.set('クリアボディ', clearBody);
+      this.registry.set('ホワイトスモーク', clearBody);
       this.registry.set('きもったま', new ScrappyEffect());
       this.registry.set('まけんき', new DefiantEffect());
       this.registry.set('かちき', new CompetitiveEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/clear-body-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/clear-body-effect.ts
@@ -1,0 +1,18 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+import { BattleContext } from '../../battle-context.interface';
+
+/**
+ * クリアボディ（Clear Body）特性の効果
+ * 自分の能力ランクが下がらない
+ *
+ * 注意: 既存の `BigPecksEffect`（はとむね）と同じく、現状はマーカー扱い。
+ *       実際の無効化処理は、能力ランクを下げる側（`BaseOpponentStatChangeMoveEffect` 等）で
+ *       本特性を参照して gating する必要がある（engine 拡張余地）。
+ *       将来的に `canReceiveStatChange` フックを追加してロジック実装に置き換える想定。
+ */
+export class ClearBodyEffect implements IAbilityEffect {
+  passiveEffect?(_pokemon: BattlePokemonStatus, _battleContext?: BattleContext): void {
+    // マーカー特性。実際の無効化処理は能力ランク変更側で gating される想定。
+  }
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **2件**を登録（マーカー）。

| 特性 | 効果（canon） |
|---|---|
| クリアボディ (Clear Body) | 自分の能力ランクが下がらない |
| ホワイトスモーク (White Smoke) | 自分の能力ランクが下がらない（クリアボディと同効果） |

### 設計メモ
- 既存 `BigPecksEffect`（はとむね、防御限定の能力低下無効）と同じ「マーカー特性」パターン
- 共通の `ClearBodyEffect` を 2 つの別名でエイリアス登録（canon 上完全に同効果）
- **本 PR は登録のみ**。実際の無効化ロジックは、`BaseOpponentStatChangeMoveEffect` / `BaseOpponentStatChangeEffect` 等の能力ランクを下げる側に新フック（`canReceiveStatChange` など）を追加して gating する必要がある
- 既存 `BigPecksEffect` の docstring にも同様の TODO 注記があり、`はとむね`／`クリアボディ`／`ホワイトスモーク` がまとめてエンジン拡張で機能するように準備された状態

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: マーカー実装のため個別 spec は割愛（BigPecks の前例に従う）。

Refs #84