### PR TITLE
feat: canReceiveStatChange フックを追加し はとむね を実機能化

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-effect.interface.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-effect.interface.ts
@@ -109,6 +109,29 @@ export interface IAbilityEffect {
   ): boolean | undefined;
 
   /**
+   * 能力ランク変更を受けられるかどうかを判定する効果
+   * @param pokemon 対象のポケモン
+   * @param statType 変更されようとしている能力（'attack'/'defense'/etc）
+   * @param rankChange ランク変化量（負の値は下降）
+   * @param battleContext バトルコンテキスト
+   * @returns 受けられる場合はtrue、無効化する場合はfalse、判定しない場合はundefined
+   *          典型用途: クリアボディ / ホワイトスモーク（全ステ低下無効）、はとむね（防御低下無効）など
+   */
+  canReceiveStatChange?(
+    _pokemon: BattlePokemonStatus,
+    _statType:
+      | 'attack'
+      | 'defense'
+      | 'specialAttack'
+      | 'specialDefense'
+      | 'speed'
+      | 'accuracy'
+      | 'evasion',
+    _rankChange: number,
+    _battleContext?: BattleContext,
+  ): boolean | undefined;
+
+  /**
    * 特定のタイプの技に対して無効化を持つかどうかを判定する効果
    * @param pokemon 対象のポケモン
    * @param typeName 技のタイプ名（日本語名、例: "じめん"）

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/big-pecks-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/big-pecks-effect.spec.ts
@@ -1,0 +1,32 @@
+import { BigPecksEffect } from './big-pecks-effect';
+import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
+
+describe('BigPecksEffect', () => {
+  let effect: BigPecksEffect;
+  const pokemon = new BattlePokemonStatus(1, 1, 1, 1, true, 100, 100, 0, 0, 0, 0, 0, 0, 0, null);
+
+  beforeEach(() => {
+    effect = new BigPecksEffect();
+  });
+
+  describe('canReceiveStatChange', () => {
+    it('防御の低下（負）は無効化（false 返却）', () => {
+      expect(effect.canReceiveStatChange(pokemon, 'defense', -1)).toBe(false);
+      expect(effect.canReceiveStatChange(pokemon, 'defense', -2)).toBe(false);
+    });
+
+    it('防御の上昇は判定しない（undefined）', () => {
+      expect(effect.canReceiveStatChange(pokemon, 'defense', 1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'defense', 2)).toBeUndefined();
+    });
+
+    it('防御以外の能力低下は判定しない（undefined）', () => {
+      expect(effect.canReceiveStatChange(pokemon, 'attack', -1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'specialAttack', -1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'specialDefense', -1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'speed', -1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'accuracy', -1)).toBeUndefined();
+      expect(effect.canReceiveStatChange(pokemon, 'evasion', -1)).toBeUndefined();
+    });
+  });
+});

--- a/server/src/modules/pokemon/domain/abilities/effects/stat-change/big-pecks-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/stat-change/big-pecks-effect.ts
@@ -2,31 +2,32 @@ import { IAbilityEffect } from '../../ability-effect.interface';
 import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
 import { BattleContext } from '../../battle-context.interface';
 
+type StatType =
+  | 'attack'
+  | 'defense'
+  | 'specialAttack'
+  | 'specialDefense'
+  | 'speed'
+  | 'accuracy'
+  | 'evasion';
+
 /**
  * はとむね（Big Pecks）特性の効果
  * 防御ランクが下がらない
  *
- * 注意: この特性は、防御ランクを下げる技や特性効果を無効化する必要がある。
- * 現在の実装では、ステータス変化を適用する前にこの特性をチェックする必要がある。
- * これは、技の特殊効果や特性効果の実装で処理される。
- *
- * この特性は、防御ランクを下げる効果を無効化するため、
- * ステータス変化を適用する際にチェックする必要がある。
- * 現在の実装では、この特性は防御ランクが下がらないことを保証するのみで、
- * 実際の無効化処理は、ステータス変化を適用する側で実装する必要がある。
+ * `canReceiveStatChange` フックで、防御ランクを下げようとする能力変化を無効化する。
+ * `BaseOpponentStatChangeMoveEffect` 等の能力変化を適用する側で本フックが参照される。
  */
 export class BigPecksEffect implements IAbilityEffect {
-  /**
-   * 防御ランクが下がることを防ぐ
-   * この特性は、防御ランクを下げる効果を無効化する必要があるが、
-   * 現在の実装では、ステータス変化を適用する側でチェックする必要がある。
-   *
-   * 注意: このメソッドは、将来的にステータス変化を適用する際に
-   * この特性をチェックするためのフラグとして使用される可能性がある。
-   * 現在の実装では、この特性は防御ランクが下がらないことを保証するのみ。
-   */
-  passiveEffect?(_pokemon: BattlePokemonStatus, _battleContext?: BattleContext): void {
-    // この特性は、防御ランクが下がらないことを保証するのみ。
-    // 実際の無効化処理は、ステータス変化を適用する側で実装する必要がある。
+  canReceiveStatChange(
+    _pokemon: BattlePokemonStatus,
+    statType: StatType,
+    rankChange: number,
+    _battleContext?: BattleContext,
+  ): boolean | undefined {
+    if (statType === 'defense' && rankChange < 0) {
+      return false;
+    }
+    return undefined;
   }
 }

--- a/server/src/modules/pokemon/domain/moves/effects/base/base-opponent-stat-change-move-effect.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base/base-opponent-stat-change-move-effect.ts
@@ -2,6 +2,7 @@ import { IMoveEffect } from '../../move-effect.interface';
 import { BattlePokemonStatus } from '@/modules/battle/domain/entities/battle-pokemon-status.entity';
 import { BattleContext } from '../../../abilities/battle-context.interface';
 import { StatType, STAT_RANK_PROP_MAP, STAT_NAME_MAP } from './base-stat-change-effect';
+import { AbilityRegistry } from '../../../abilities/ability-registry';
 
 /**
  * 相手のステータスランクを変更する変化技の基底クラス
@@ -31,6 +32,32 @@ export abstract class BaseOpponentStatChangeMoveEffect implements IMoveEffect {
   ): Promise<string | null> {
     if (!battleContext.battleRepository) {
       return null;
+    }
+
+    // 能力ランク変化を防御側の特性で無効化チェック
+    // 攻撃側がかたやぶりを持っている場合は、防御側の特性効果を無視（既存パターン踏襲）
+    if (
+      this.rankChange < 0 &&
+      battleContext.trainedPokemonRepository &&
+      !AbilityRegistry.hasMoldBreaker(battleContext.attackerAbilityName)
+    ) {
+      const defenderTrainedPokemon = await battleContext.trainedPokemonRepository.findById(
+        defender.trainedPokemonId,
+      );
+      if (defenderTrainedPokemon?.ability) {
+        const defenderAbility = AbilityRegistry.get(defenderTrainedPokemon.ability.name);
+        if (defenderAbility?.canReceiveStatChange) {
+          const canReceive = defenderAbility.canReceiveStatChange(
+            defender,
+            this.statType,
+            this.rankChange,
+            battleContext,
+          );
+          if (canReceive === false) {
+            return null;
+          }
+        }
+      }
     }
 
     // 現在のランクを取得


### PR DESCRIPTION
## Summary
これまで「マーカーのみ」だった `BigPecksEffect`（はとむね）を実機能化するための engine 拡張。新フック `canReceiveStatChange` を追加し、能力低下を防御側の特性で gating できるようにする。

### 変更内容
1. **`IAbilityEffect` インターフェース拡張**
   - 新フック `canReceiveStatChange(pokemon, statType, rankChange, battleContext): boolean | undefined`
   - 既存の `canReceiveStatusCondition` と同形（false で無効化、undefined で判定不要）
2. **`BaseOpponentStatChangeMoveEffect` に gating ロジック追加**
   - 能力を下げる技（rankChange < 0）使用時、防御側の特性 `canReceiveStatChange` を確認
   - 攻撃側が `かたやぶり` を持つ場合は無視（既存 `canReceiveStatusCondition` と同パターン）
3. **`BigPecksEffect` を実機能化**
   - これまで docstring に「マーカーで実装不完全」と注記されていた状態を解消
   - `statType === 'defense' && rankChange < 0` の場合のみ `false` を返す

### Before / After
- **Before**: にらみつける (Leer) を打たれてもはとむねの効果が無く防御 -1
- **After**: にらみつける (Leer) を打たれてもはとむねがブロック

### 関連 PR
- **#231（クリアボディ / ホワイトスモーク）**: 同フックを使えば実機能化できる。本 PR マージ後に follow-up で `canReceiveStatChange` を実装する形で更新可能
- **IntimidateEffect 等の ability-side stat change** はまだ gating されていない（`BaseOpponentStatChangeEffect` 側も同様の hook 呼び出し追加が必要）

## Test plan
- [x] `big-pecks-effect.spec.ts` 追加: 3ケース（防御低下無効化 / 防御上昇は判定なし / 他能力低下は判定なし）
- [x] `npm test`: 120 suites / 694 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84