### PR TITLE
feat: canReceiveStatChange gating を ability-side にも適用

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/effects/base/base-opponent-stat-change-effect.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/base/base-opponent-stat-change-effect.ts
@@ -56,6 +56,32 @@ export abstract class BaseOpponentStatChangeEffect implements IAbilityEffect {
       return;
     }
 
+    // 能力ランク低下を相手の特性で gating（クリアボディ/はとむね 等）
+    // 攻撃側がかたやぶりを持っている場合は無視（既存パターン踏襲）
+    // 動的インポートで循環参照を回避（既存 base-contact-status-condition-effect.ts と同方針）
+    if (this.rankChange < 0 && battleContext.trainedPokemonRepository) {
+      const { AbilityRegistry } = await import('../../ability-registry');
+      if (!AbilityRegistry.hasMoldBreaker(battleContext.attackerAbilityName)) {
+        const opponentTrainedPokemon = await battleContext.trainedPokemonRepository.findById(
+          opponentPokemon.trainedPokemonId,
+        );
+        if (opponentTrainedPokemon?.ability) {
+          const opponentAbility = AbilityRegistry.get(opponentTrainedPokemon.ability.name);
+          if (opponentAbility?.canReceiveStatChange) {
+            const canReceive = opponentAbility.canReceiveStatChange(
+              opponentPokemon,
+              this.statType,
+              this.rankChange,
+              battleContext,
+            );
+            if (canReceive === false) {
+              return;
+            }
+          }
+        }
+      }
+    }
+
     // 現在のランクを取得
     const currentRank = opponentPokemon.getStatRank(this.statType);
 


### PR DESCRIPTION
## Summary
**PR #232 の follow-up**。move-side の `BaseOpponentStatChangeMoveEffect` に加えて、ability-side の `BaseOpponentStatChangeEffect`（`IntimidateEffect` 等が継承）でも能力ランク低下を gating する。

### 変更
`BaseOpponentStatChangeEffect.onEntry` で:
1. `this.rankChange < 0` のとき、相手の特性 `canReceiveStatChange` を確認
2. `かたやぶり` を持つ場合は無視（既存パターン）
3. 動的インポートで `AbilityRegistry` を取得（循環参照を回避、既存 `base-contact-status-condition-effect.ts` と同方針）

### 注意
- このベースを使う ability は現状 `IntimidateEffect`（攻撃 -1）のみ
- 既存の唯一の `canReceiveStatChange` 実装である `BigPecksEffect`（防御限定）とは能力種が異なるため、現状の組み合わせでは挙動変化なし
- 将来 `ClearBodyEffect` 等の全ステ低下無効が実装されれば正しく gating される（**forward-compat**）

### 依存
本 PR は **#232 をベースに分岐** しています。マージ順序: #232 → 本 PR。

## Test plan
- [x] `npm test`: 120 suites / 694 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

Refs #84