### PR TITLE
test: Thunder/ThunderShock/Psychic の確率テスト flake を解消

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/psychic-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/psychic-effect.spec.ts
@@ -69,25 +69,36 @@ describe('PsychicEffect', () => {
   });
 
   describe('onHit', () => {
-    it('10%の確率で特防ランクを1段階下げる', async () => {
-      const effect = new PsychicEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus({ specialDefenseRank: 0 });
-      const battleContext = createBattleContext();
+    describe('10%で特防ランクを1段階下げる確率分岐', () => {
+      // 旧テストは 1000 回試行で 70-130 回を期待していた確率テスト。
+      // 二項分布の揺らぎを避けるため Math.random を決定的にモックする形に置き換える
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 1000; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
+      it('Math.random < 0.1 なら特防 -1', async () => {
+        const effect = new PsychicEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus({ specialDefenseRank: 0 });
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.05);
+
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 10%の確率なので、7%以上13%以下になることが期待される（70-130回）
-      expect(successCount).toBeGreaterThan(70);
-      expect(successCount).toBeLessThan(130);
+        expect(result).not.toBeNull();
+      });
+
+      it('Math.random >= 0.1 なら特防は下がらない', async () => {
+        const effect = new PsychicEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus({ specialDefenseRank: 0 });
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
     });
   });
 });

--- a/server/src/modules/pokemon/domain/moves/effects/thunder-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/thunder-effect.spec.ts
@@ -82,25 +82,36 @@ describe('ThunderEffect', () => {
   });
 
   describe('onHit', () => {
-    it('30%の確率でまひを付与する', async () => {
-      const effect = new ThunderEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
+    describe('30%でまひを付与する確率分岐', () => {
+      // 旧テストは 1000 回試行で 270-330 回を期待していたが、二項分布の確率的揺らぎで
+      // ~5% の確率で flake していたため、Math.random を決定的にモックする形に置き換える
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 1000; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
+      it('Math.random < 0.3 ならまひを付与', async () => {
+        const effect = new ThunderEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 30%の確率なので、27%以上33%以下になることが期待される（270-330回）
-      expect(successCount).toBeGreaterThan(270);
-      expect(successCount).toBeLessThan(330);
+        expect(result).toBe('was paralyzed!');
+      });
+
+      it('Math.random >= 0.3 ならまひを付与しない', async () => {
+        const effect = new ThunderEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
     });
   });
 });

--- a/server/src/modules/pokemon/domain/moves/effects/thunder-shock-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/thunder-shock-effect.spec.ts
@@ -82,25 +82,36 @@ describe('ThunderShockEffect', () => {
   });
 
   describe('onHit', () => {
-    it('10%の確率でまひを付与する', async () => {
-      const effect = new ThunderShockEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
+    describe('10%でまひを付与する確率分岐', () => {
+      // 旧テストは 1000 回試行で 70-130 回を期待していた確率テスト。
+      // 二項分布の揺らぎを避けるため Math.random を決定的にモックする形に置き換える
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 1000; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
+      it('Math.random < 0.1 ならまひを付与', async () => {
+        const effect = new ThunderShockEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.05);
+
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 10%の確率なので、7%以上13%以下になることが期待される（70-130回）
-      expect(successCount).toBeGreaterThan(70);
-      expect(successCount).toBeLessThan(130);
+        expect(result).toBe('was paralyzed!');
+      });
+
+      it('Math.random >= 0.1 ならまひを付与しない', async () => {
+        const effect = new ThunderShockEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
PR #230（エアスラッシュ flake fix）と同パターンの追加 flake 修正。

### 問題
以下 3 つのテストはいずれも「N 回試行して成功カウントが範囲内」型の統計テストで、二項分布の確率的揺らぎで flake する設計:
- `thunder-effect.spec.ts` (30%, 1000 試行, 270-330): 二項分布 stdev ≈ 14.5、範囲は ±2σ → **約 5% で flake**
- `thunder-shock-effect.spec.ts` (10%, 1000 試行, 70-130): stdev ≈ 9.5、範囲は ±3σ で比較的安定だが原理は同じ
- `psychic-effect.spec.ts` (10%, 1000 試行, 70-130): 同上

### 観測
**直近の cron 実行で `thunder-effect` が実際に失敗**（成功 335 回、上限 330 で外れ）。

### 修正
PR #230 と同じパターンで `Math.random` を `jest.spyOn` で決定的にモック化し、確率分岐の各経路を直接検証:
- < threshold → 効果発動
- >= threshold → スキップ

決定的になったため flake が原理的に発生しなくなる。

## Test plan
- [x] 3 つのテストを個別に 3 回連続実行して安定確認
- [x] `npm test`: 119 suites / 694 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過