### PR TITLE
test: 複数状態異常付与の確率テスト flake を解消

### DIFF
--- a/server/src/modules/pokemon/domain/moves/effects/base-multiple-status-condition-effect.spec.ts
+++ b/server/src/modules/pokemon/domain/moves/effects/base-multiple-status-condition-effect.spec.ts
@@ -148,109 +148,77 @@ describe('BaseMultipleStatusConditionEffect', () => {
       );
     });
 
-    it('確率に基づいて状態異常を付与する', async () => {
-      const effect = new FireFangEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
-
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 100; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
-        const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
-
-      const successCount = results.filter(r => r !== null).length;
-      // 2つの独立した10%の確率で少なくとも1つが成功する確率は約19% (1 - 0.9 × 0.9)
-      // 100試行での標準偏差は約3.9のため、10以上35未満で統計的なばらつきを許容する
-      expect(successCount).toBeGreaterThan(9);
-      expect(successCount).toBeLessThan(35);
-    });
-
-    it('ほのおのキバは10%の確率でひるみまたはやけどを付与する', async () => {
-      const effect = new FireFangEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
-
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 100; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
-        const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
-
-      const successCount = results.filter(r => r !== null).length;
-      // 2つの独立した10%の確率で少なくとも1つが成功する確率は約19% (1 - 0.9 × 0.9)
-      // 100試行での標準偏差は約3.9のため、10以上35未満で統計的なばらつきを許容する
-      expect(successCount).toBeGreaterThan(9);
-      expect(successCount).toBeLessThan(35);
-
-      // 成功した場合、ひるみまたはやけどが付与される
-      const successResults = results.filter(r => r !== null);
-      successResults.forEach(result => {
-        expect(result).toMatch(/flinched!|was burned!/);
+    // 旧テスト群は 100 試行で 10-34 件のヒットを期待する統計テストで、二項分布の
+    // 揺らぎで flake する設計だった（PR #230 と同パターン）。`Math.random` を
+    // 決定的にモックして確率分岐を直接検証する形に置き換える。
+    describe('確率分岐（Math.random 決定モック）', () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
       });
-    });
 
-    it('こおりのキバは10%の確率でひるみまたはこおりを付与する', async () => {
-      const effect = new IceFangEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
+      it('1 つ目の効果（ひるみ）の確率を通過したらそれが適用される', async () => {
+        const effect = new FireFangEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        // 1つ目のロールで成功
+        jest.spyOn(Math, 'random').mockReturnValue(0.05);
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 100; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 2つの独立した10%の確率で少なくとも1つが成功する確率は約19% (1 - 0.9 × 0.9)
-      // 100試行での標準偏差は約3.9のため、10以上35未満で統計的なばらつきを許容する
-      expect(successCount).toBeGreaterThan(9);
-      expect(successCount).toBeLessThan(35);
-
-      // 成功した場合、ひるみまたはこおりが付与される
-      const successResults = results.filter(r => r !== null);
-      successResults.forEach(result => {
-        expect(result).toMatch(/flinched!|was frozen solid!/);
+        expect(result).toBe('flinched!');
       });
-    });
 
-    it('かみなりのキバは10%の確率でひるみまたはまひを付与する', async () => {
-      const effect = new ThunderFangEffect();
-      const attacker = createBattlePokemonStatus();
-      const defender = createBattlePokemonStatus();
-      const battleContext = createBattleContext();
+      it('1 つ目を外し 2 つ目（やけど）が通れば 2 つ目が適用される', async () => {
+        const effect = new FireFangEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        // 1回目: 0.2 で外す（>= 0.1）、2回目: 0.05 で通す
+        const rand = jest.spyOn(Math, 'random');
+        rand.mockReturnValueOnce(0.2).mockReturnValueOnce(0.05);
 
-      // 複数回実行して確率的な動作を確認
-      const results: (string | null)[] = [];
-      for (let i = 0; i < 100; i++) {
-        // モックをリセット
-        (battleContext.battleRepository?.updateBattlePokemonStatus as jest.Mock).mockClear();
         const result = await effect.onHit(attacker, defender, battleContext);
-        results.push(result);
-      }
 
-      const successCount = results.filter(r => r !== null).length;
-      // 2つの独立した10%の確率で少なくとも1つが成功する確率は約19% (1 - 0.9 × 0.9)
-      // 100試行での標準偏差は約3.9のため、10以上35未満で統計的なばらつきを許容する
-      expect(successCount).toBeGreaterThan(9);
-      expect(successCount).toBeLessThan(35);
+        expect(result).toBe('was burned!');
+      });
 
-      // 成功した場合、ひるみまたはまひが付与される
-      const successResults = results.filter(r => r !== null);
-      successResults.forEach(result => {
-        expect(result).toMatch(/flinched!|is paralyzed! It may be unable to move!/);
+      it('両方とも確率を外すと何も付与されない', async () => {
+        const effect = new FireFangEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBeNull();
+      });
+
+      it('こおりのキバ: 2 つ目を通すとこおりが付与される', async () => {
+        const effect = new IceFangEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        const rand = jest.spyOn(Math, 'random');
+        rand.mockReturnValueOnce(0.5).mockReturnValueOnce(0.05);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toBe('was frozen solid!');
+      });
+
+      it('かみなりのキバ: 2 つ目を通すとまひが付与される', async () => {
+        const effect = new ThunderFangEffect();
+        const attacker = createBattlePokemonStatus();
+        const defender = createBattlePokemonStatus();
+        const battleContext = createBattleContext();
+        const rand = jest.spyOn(Math, 'random');
+        rand.mockReturnValueOnce(0.5).mockReturnValueOnce(0.05);
+
+        const result = await effect.onHit(attacker, defender, battleContext);
+
+        expect(result).toMatch(/paralyzed/);
       });
     });
   });


### PR DESCRIPTION
## Summary
PR #230（エアスラッシュ）/ #234（Thunder/ThunderShock/Psychic）と同パターンの追加 flake 修正。

### 問題
`base-multiple-status-condition-effect.spec.ts` の 4 つの確率テストはいずれも 100 試行で 10-34 件のヒットを期待していた:
- 確率に基づいて状態異常を付与する (FireFangEffect)
- ほのおのキバは10%の確率でひるみまたはやけどを付与する
- こおりのキバは10%の確率でひるみまたはこおりを付与する
- かみなりのキバは10%の確率でひるみまたはまひを付与する

期待される成功率は約 19%（10% × 2 の独立試行で「少なくとも 1 つ」）、平均 19, stdev ≈ 3.92。範囲 9-35（exclusive）の下限が borderline で flake する。

### 修正
`Math.random` を `jest.spyOn` で決定的にモックし、各確率分岐を直接検証する 5 つの新テストに置き換え:
1. 1 つ目の効果（ひるみ）の確率を通過 → ひるみ付与
2. 1 つ目を外し 2 つ目（やけど）が通れば 2 つ目が適用（FireFang）
3. 両方外れば null
4. IceFang: 2 つ目（こおり）の経路
5. ThunderFang: 2 つ目（まひ）の経路

`mockReturnValueOnce` を順に使って、`Math.random` の連続呼び出しを別々の経路に振り分ける。

## Test plan
- [x] `npx jest base-multiple-status-condition-effect`: 8 tests Pass
- [x] `npm test`: 119 suites / 692 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過