### PR TITLE
feat: バトル中効果なしの特性を登録 (Issue #84一部、3件)

### DIFF
--- a/server/src/modules/pokemon/domain/abilities/ability-registry.ts
+++ b/server/src/modules/pokemon/domain/abilities/ability-registry.ts
@@ -59,6 +59,7 @@ import { PranksterEffect } from './effects/other/prankster-effect';
 import { NoGuardEffect } from './effects/other/no-guard-effect';
 import { NaturalCureEffect } from './effects/other/natural-cure-effect';
 import { RegeneratorEffect } from './effects/other/regenerator-effect';
+import { NoBattleEffectAbility } from './effects/other/no-battle-effect-ability';
 import { InnerFocusEffect } from './effects/other/inner-focus-effect';
 import { LimberEffect } from './effects/other/limber-effect';
 import { MagmaArmorEffect } from './effects/other/magma-armor-effect';
@@ -187,6 +188,12 @@ export class AbilityRegistry {
       // 場から下がるとき発動（Issue #84 一部）
       this.registry.set('しぜんかいふく', new NaturalCureEffect());
       this.registry.set('さいせいりょく', new RegeneratorEffect());
+      // バトル中効果なしの特性（Issue #84 一部）
+      // 単一の NoBattleEffectAbility インスタンスを複数の特性で共有
+      const noBattleEffect = new NoBattleEffectAbility();
+      this.registry.set('にげあし', noBattleEffect);
+      this.registry.set('はっこう', noBattleEffect);
+      this.registry.set('ハッピータイム', noBattleEffect);
       this.registry.set('せいしんりょく', new InnerFocusEffect());
       this.registry.set('じゅうなん', new LimberEffect());
       this.registry.set('マグマのよろい', new MagmaArmorEffect());

--- a/server/src/modules/pokemon/domain/abilities/effects/other/no-battle-effect-ability.ts
+++ b/server/src/modules/pokemon/domain/abilities/effects/other/no-battle-effect-ability.ts
@@ -1,0 +1,17 @@
+import { IAbilityEffect } from '../../ability-effect.interface';
+
+/**
+ * バトル中に効果を持たない特性の共通実装
+ *
+ * 用途: 野生エンカウント率や逃走可否のみに影響し、バトル中は何もしない特性。
+ *       例:
+ *       - にげあし（Run Away）: 野生バトルから必ず逃げられる（バトル中効果なし）
+ *       - はっこう（Illuminate）: 野生エンカウント率を上げる（バトル中効果なし、Gen8以前）
+ *       - ハッピータイム（Happy Hour）: 賞金が2倍（バトル中効果なし）
+ *
+ * 単一の stateless インスタンスを複数の特性名にエイリアス登録できる。
+ * 既存の MoveRegistry の `NoOpEffect` と同様の設計。
+ */
+export class NoBattleEffectAbility implements IAbilityEffect {
+  // すべてのオプショナルメソッドを実装しない（バトル中は何もしない）
+}


### PR DESCRIPTION
## Summary
Issue #84「その他カテゴリの未実装特性 (318件)」から **3件**を登録。野生エンカウントや賞金にのみ影響し、バトル中は何もしない特性。

| 特性 | canon の効果 |
|---|---|
| にげあし (Run Away) | 野生バトルから必ず逃げられる |
| はっこう (Illuminate) | 野生エンカウント率を上げる（Gen8 以前） |
| ハッピータイム (Happy Hour) | 賞金が 2 倍 |

いずれもバトル中の戦闘ロジックには関与しない。

### 設計メモ
- 新規 `NoBattleEffectAbility` クラス（オプショナルメソッドを 1 つも実装しない空実装）
- 単一インスタンスを 3 特性で共有エイリアス登録
- 既存 `MoveRegistry` の `NoOpEffect`（はねる/おいわい/てをつなぐ）と同設計

### 何のため
- `MoveRegistry` の coverage チェック（`check:coverage`）と同様に、`AbilityRegistry` でもカテゴリーカバレッジを進めるため
- これらは「未実装」と「実装したが効果なし（仕様通り）」を区別するマーカーとしても機能

## Test plan
- [x] `npm test`: 119 suites / 691 tests Pass
- [x] `npm run lint`: 通過
- [x] `npm run build`: 通過

注: 空クラスのため個別 spec は割愛。

Refs #84